### PR TITLE
Import JSX type and move @types/react to devDependencies

### DIFF
--- a/components/utils/categories.ts
+++ b/components/utils/categories.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import { ChartBarIcon, CurrencyDollarIcon, DatabaseIcon, ServerIcon } from "../icons/categoryIcons";
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.2.0",
       "dependencies": {
         "@types/node": "25.3.2",
-        "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "eslint": "10.0.2",
         "eslint-config-next": "16.1.6",
@@ -27,6 +26,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/react": "19.2.14",
         "@types/testing-library__jest-dom": "^6.0.0",
         "autoprefixer": "^10.4.27",
         "jest": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@types/node": "25.3.2",
-    "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "eslint": "10.0.2",
     "eslint-config-next": "16.1.6",
@@ -36,6 +35,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "@types/react": "19.2.14"
   }
 }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error where `JSX.Element` was unresolved in `components/utils/categories.ts` by ensuring the `JSX` namespace is imported from React. 
- Ensure React type definitions are provided as a dev-time dependency rather than a runtime dependency so type-checking works correctly without affecting production bundle. 
- Keep the lockfile consistent with the dependency placement.

### Description
- Added `import type { JSX } from 'react';` at the top of `components/utils/categories.ts` so the `JSX.Element` annotation resolves. 
- Moved `@types/react` from `dependencies` into `devDependencies` in `package.json`. 
- Regenerated `package-lock.json` (via `npm install --package-lock-only`) so the lockfile reflects the change.

### Testing
- Attempted `npm install --save-dev @types/react`, which failed in this environment with a `403 Forbidden` from the registry. 
- Ran `npm install --package-lock-only` to update the lockfile, which completed successfully. 
- Ran `npm run build`; TypeScript compilation progressed but the build failed on an unrelated existing type error in `pages/_document.tsx` (`crossOrigin="true"` not assignable to `CrossOrigin`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33d8995248332b1a66d0fbd8f8377)