### PR TITLE
Fix output arrow centering in data warehouse architecture SVG

### DIFF
--- a/public/images/data-warehouse-architecture.svg
+++ b/public/images/data-warehouse-architecture.svg
@@ -101,7 +101,7 @@
   <path class="line" d="M234 1200 H276"/>
   <path class="line" d="M398 1200 H440"/>
   <path class="line" d="M562 1200 H604"/>
-  <path class="line" d="M738 1220 H810"/>
+  <path class="line" d="M738 1220 H778"/>
   <path class="line" d="M396 810 V890 H279 V1018"/>
   <path class="line" d="M738 1018 H824 V761 H788"/>
 

--- a/public/images/data-warehouse-architecture.svg
+++ b/public/images/data-warehouse-architecture.svg
@@ -101,7 +101,7 @@
   <path class="line" d="M234 1200 H276"/>
   <path class="line" d="M398 1200 H440"/>
   <path class="line" d="M562 1200 H604"/>
-  <path class="line" d="M738 1064 H790"/>
+  <path class="line" d="M738 1220 H810"/>
   <path class="line" d="M396 810 V890 H279 V1018"/>
   <path class="line" d="M738 1018 H824 V761 H788"/>
 


### PR DESCRIPTION
## Summary
- The output arrow in `public/images/data-warehouse-architecture.svg` pointed only at the "Internal" icon near the top of the business users group, instead of being centered against the full Internal/Clients/Partners stack.
- Adjusted the arrow's path so it now terminates at the vertical center of that group.

## Test plan
- [x] Rendered the SVG to PNG (headless Chromium) before and after the change to visually confirm the arrow is now centered on the Internal/Clients/Partners group.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd4DgvPXZjXHWgQnxAZED9)_