### PR TITLE
Cap Lambda concurrency at 50

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -82,6 +82,7 @@ functions:
     handler: run.sh
     timeout: 28
     memorySize: 1024
+    reservedConcurrency: 50
     layers:
       - arn:aws:lambda:${aws:region}:753240598075:layer:LambdaAdapterLayerX86:20
     environment:


### PR DESCRIPTION
## What changed

Set the portfolio web Lambda's `reservedConcurrency` to 50 in `serverless.yml`.

## Behaviour

This caps the function at 50 concurrent executions. It does not keep 50 instances running or create a minimum concurrency. Provisioned concurrency is the separate setting that pre-warms a minimum number of instances.

## Impact

Requests above 50 concurrent executions will be throttled until capacity becomes available.

## Validation

Configuration change only; no application code changed.