### PR TITLE
Rename book nebula shape to document

### DIFF
--- a/components/composites/ShapeMorphButtons.tsx
+++ b/components/composites/ShapeMorphButtons.tsx
@@ -3,7 +3,7 @@ import InteractiveFigure from "./InteractiveFigure";
 const SHAPES: { key: string; label: string }[] = [
   { key: "spark", label: "Spark" },
   { key: "hex", label: "Hexagon" },
-  { key: "book", label: "Book" },
+  { key: "plane", label: "Arrow" },
   { key: "nodes", label: "Node web" },
   { key: "db", label: "Database" },
   { key: "cloud", label: "Cloud" },

--- a/lib/nebula/shapes.ts
+++ b/lib/nebula/shapes.ts
@@ -13,7 +13,7 @@ export const nebulaShapes: Record<string, string> = {
   hex: "M50 6 L88 28 L88 72 L50 94 L12 72 L12 28 Z",
   // Document page with a folded corner: a single strong silhouette for
   // insights and reading, without internal contours that split the gas.
-  book:
+  document:
     "M18 7 L64 7 L88 31 L88 93 L18 93 Z",
   // Magnifying glass: reading, inspecting, and exploring an insight.
   article:
@@ -81,7 +81,7 @@ const tagShapes: Record<string, NebulaShapeKey> = {
   "home-automation": "cloud",
 };
 
-/** Insight tags map to glyphs; anything unknown gets the book. */
+/** Insight tags map to glyphs; anything unknown gets the article shape. */
 export function tagShape(tag: string): NebulaShapeKey {
   return tagShapes[tag] ?? "article";
 }

--- a/tests/interactive.test.tsx
+++ b/tests/interactive.test.tsx
@@ -100,7 +100,7 @@ describe("HomelabDiagram", () => {
 describe("ShapeMorphButtons", () => {
   it("renders a real data-nebula-shape trigger for every shape", () => {
     render(<ShapeMorphButtons />);
-    for (const key of ["spark", "hex", "book", "nodes", "db", "cloud"]) {
+    for (const key of ["spark", "hex", "plane", "nodes", "db", "cloud"]) {
       expect(screen.getByTestId(`shape-${key}`)).toHaveAttribute("data-nebula-shape", key);
     }
   });


### PR DESCRIPTION
## What changed

Renamed the `book` nebula shape key to `document` to match the actual folded-page silhouette.

Updated the “How this site works” shape demo to use the existing paper-plane shape labelled as `Arrow` instead of the document shape.

Updated the related interactive test expectations.

## Validation

Configuration and test references were updated together. No rendering geometry changed.