### PR TITLE
feat: add breadcrumbs sitewide

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import SectionHeading from "@/components/composites/SectionHeading";
+import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import JsonLd from "@/components/ui/JsonLd";
 import CareerTimeline from "@/components/composites/CareerTimeline";
 import CapabilityList from "@/components/composites/CapabilityList";
@@ -12,7 +13,7 @@ import Heading from "@/components/ui/Heading";
 import Text from "@/components/ui/Text";
 import Panel from "@/components/ui/Panel";
 import { getCareerEntries, getSkillDomains, getWorkIntro } from "@/lib/content";
-import { pageMetadata, profilePageSchema } from "@/lib/seo";
+import { pageMetadata, profilePageSchema, breadcrumbSchema } from "@/lib/seo";
 import { site } from "@/lib/site";
 
 export const metadata: Metadata = pageMetadata({
@@ -36,6 +37,13 @@ export default function AboutPage() {
         color="aurora"
       />
       <JsonLd data={profilePageSchema()} />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "About", path: "/about" },
+        ])}
+      />
+      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "About" }]} />
 
       <div className="flex flex-col-reverse gap-8 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -3,11 +3,13 @@ import Image from "next/image";
 import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import SectionHeading from "@/components/composites/SectionHeading";
+import Breadcrumbs from "@/components/composites/Breadcrumbs";
+import JsonLd from "@/components/ui/JsonLd";
 import TextLink from "@/components/ui/TextLink";
 import Icon, { IconName } from "@/components/ui/Icon";
 import Text from "@/components/ui/Text";
 import { site, socialChannels, SocialChannel } from "@/lib/site";
-import { pageMetadata } from "@/lib/seo";
+import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
   title: "Contact",
@@ -28,6 +30,14 @@ export default function ContactPage() {
       {/* Channels fill the left column; the lower-right stays open
           below the portrait. */}
       <NebulaBackground variant="mini" corner="bottom-right" miniShape="crab" color="solar" />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Contact", path: "/contact" },
+        ])}
+      />
+      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Contact" }]} />
+
       <div className="grid gap-12 lg:grid-cols-[1fr_minmax(16rem,24rem)]">
         <div className="min-w-0">
           <SectionHeading

--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -71,11 +71,18 @@ export default async function InsightPage({ params }: PageProps) {
       <JsonLd data={articleSchema(insight)} />
       <JsonLd
         data={breadcrumbSchema([
+          { name: "Home", path: "/" },
           { name: "Insights", path: "/insights" },
           { name: insight.title, path: `/insights/${slug}` },
         ])}
       />
-      <Breadcrumbs items={[{ label: "Insights", href: "/insights" }, { label: insight.title }]} />
+      <Breadcrumbs
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Insights", href: "/insights" },
+          { label: insight.title },
+        ]}
+      />
 
       <header>
         <Heading size="page">{insight.title}</Heading>

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -2,10 +2,12 @@ import type { Metadata } from "next";
 import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import SectionHeading from "@/components/composites/SectionHeading";
+import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import DividedList from "@/components/composites/DividedList";
 import InsightListItem from "@/components/composites/InsightListItem";
+import JsonLd from "@/components/ui/JsonLd";
 import { getInsights } from "@/lib/content";
-import { pageMetadata } from "@/lib/seo";
+import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
   title: "Insights",
@@ -27,6 +29,14 @@ export default function InsightsPage() {
         color="aurora"
         size="lg"
       />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Insights", path: "/insights" },
+        ])}
+      />
+      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Insights" }]} />
+
       <SectionHeading
         eyebrow="Insights"
         title="Write-ups from production"

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import SectionHeading from "@/components/composites/SectionHeading";
+import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import ProjectCard from "@/components/composites/ProjectCard";
+import JsonLd from "@/components/ui/JsonLd";
 import { getProjectsByEra } from "@/lib/content";
-import { pageMetadata } from "@/lib/seo";
+import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
   title: "Projects",
@@ -22,6 +24,14 @@ export default function ProjectsPage() {
       {/* The heading block is left-aligned; the upper-right is open
           before the card grid begins. */}
       <NebulaBackground variant="mini" corner="top-right" miniShape="crab" color="frost" />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Projects", path: "/projects" },
+        ])}
+      />
+      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Projects" }]} />
+
       <div className="mb-12">
         <SectionHeading
           eyebrow="Projects"

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -83,13 +83,18 @@ export default async function CaseStudyPage({ params }: PageProps) {
       <NebulaBackground variant="mini" corner="top-right" miniShape="helix" color="frost" />
       <JsonLd
         data={breadcrumbSchema([
+          { name: "Home", path: "/" },
           { name: "Work", path: "/work" },
           { name: caseStudy.title, path: `/work/${slug}` },
         ])}
       />
       <JsonLd data={caseStudySchema(caseStudy)} />
       <Breadcrumbs
-        items={[{ label: "Work", href: "/work" }, { label: caseStudy.title }]}
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Work", href: "/work" },
+          { label: caseStudy.title },
+        ]}
       />
 
       <header>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -2,13 +2,15 @@ import type { Metadata } from "next";
 import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import SectionHeading from "@/components/composites/SectionHeading";
+import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import CapabilityList from "@/components/composites/CapabilityList";
 import DividedList from "@/components/composites/DividedList";
 import CaseStudyListItem from "@/components/composites/CaseStudyListItem";
 import Heading from "@/components/ui/Heading";
 import Text from "@/components/ui/Text";
+import JsonLd from "@/components/ui/JsonLd";
 import { getCaseStudies, getWorkIntro } from "@/lib/content";
-import { pageMetadata } from "@/lib/seo";
+import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
   title: "Work",
@@ -25,6 +27,14 @@ export default function WorkPage() {
     <PageShell>
       {/* The intro is capped at prose width, leaving the upper-right open. */}
       <NebulaBackground variant="mini" corner="top-right" miniShape="orion" color="solar" />
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Work", path: "/work" },
+        ])}
+      />
+      <Breadcrumbs items={[{ label: "Home", href: "/" }, { label: "Work" }]} />
+
       <div className="max-w-prose">
         <SectionHeading eyebrow="Case studies" title={intro.title} asPageTitle />
         <Text variant="muted" className="mt-5">


### PR DESCRIPTION
Every page now gets a Home > Section > Page trail, both visually (Breadcrumbs) and as BreadcrumbList JSON-LD, not just the nested work/insights detail pages. Matches the standard location-based breadcrumb pattern and Google's structured data guidelines.