### PR TITLE
perf: inline CSS to remove the render-blocking stylesheet

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,11 @@ const path = require("path");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Inline CSS into the HTML so the stylesheet stops blocking first
+  // render (App Router native; optimizeCss/beasties is Pages-only).
+  experimental: {
+    inlineCss: true,
+  },
   // Self-contained server build, deployed to Lambda behind CloudFront.
   output: "standalone",
   images: {


### PR DESCRIPTION
App Router ships one render-blocking <link rel="stylesheet"> in <head>. experimental.inlineCss inlines it into the HTML so styles arrive with the document instead of costing a blocking round-trip, clearing the render-blocking-requests audit. (optimizeCss/beasties is Pages-Router only.)