### PR TITLE
Drop Engineering Director from sitewide OG/title tagline

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ const mono = JetBrains_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL(site.url),
   title: {
-    default: `${site.name} · ${site.role}`,
+    default: `${site.name} · ${site.tagline}`,
     template: `%s · ${site.name}`,
   },
   description: site.description,
@@ -51,13 +51,13 @@ export const metadata: Metadata = {
     type: "website",
     siteName: site.name,
     url: site.url,
-    title: `${site.name} · ${site.role}`,
+    title: `${site.name} · ${site.tagline}`,
     description: site.description,
     locale: "en_CA",
   },
   twitter: {
     card: "summary_large_image",
-    title: `${site.name} · ${site.role}`,
+    title: `${site.name} · ${site.tagline}`,
     description: site.description,
   },
   icons: {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -12,7 +12,7 @@ import { site } from "@/lib/site";
  * inlined as JPEG because satori does not decode webp.
  */
 
-export const alt = `${site.name} · ${site.role}`;
+export const alt = `${site.name} · ${site.tagline}`;
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -4,7 +4,13 @@
  */
 export const site = {
   name: "Art Nikitin",
-  role: "Hands-on Architect",
+  // Actual job title: feeds structured data (jobTitle) and llms.txt,
+  // where accuracy matters more than how it reads on a page.
+  role: "Engineering Director & Hands-on Architect",
+  // Public-facing headline: everywhere a title/preview is shown to a
+  // reader (page title, OG/twitter cards, opengraph-image alt). Kept
+  // separate from `role` so those surfaces can drop the job title.
+  tagline: "Hands-on Architect",
   domain: "artnikitin.dev",
   url: process.env.SITE_URL || "https://artnikitin.dev",
   email: "hello@artnikitin.dev",

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -4,7 +4,7 @@
  */
 export const site = {
   name: "Art Nikitin",
-  role: "Engineering Director & Hands-on Architect",
+  role: "Hands-on Architect",
   domain: "artnikitin.dev",
   url: process.env.SITE_URL || "https://artnikitin.dev",
   email: "hello@artnikitin.dev",
@@ -12,7 +12,7 @@ export const site = {
   github: "https://github.com/NeedToUpdate",
   linkedin: "https://linkedin.com/in/art-nikitin-dev",
   description:
-    "Engineering director and hands-on architect. I design the systems enterprises run on and lead the teams that build them.",
+    "I design the systems enterprises run on and lead the teams that build them.",
 } as const;
 
 export interface SocialChannel {


### PR DESCRIPTION
The homepage hero already moved to "I design the systems
enterprises run on." for the same reason; site.role/description
feed the OG title, description, twitter card, jobTitle schema,
and llms.txt, so they were still surfacing it there. The About
page keeps its own separate description with the full title.