### PR TITLE
Per-file precise CloudFront invalidation via the import graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
         "@types/react": "^19.2.17",
+        "dependency-cruiser": "^17.4.3",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "postcss": "^8.5.16",
@@ -4719,6 +4720,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5131,6 +5133,39 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/adm-zip": {
@@ -6699,6 +6734,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -6838,6 +6883,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d": {
@@ -7377,6 +7423,107 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dependency-cruiser": {
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.4.3.tgz",
+      "integrity": "sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "8.16.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "14.0.3",
+        "enhanced-resolve": "5.22.1",
+        "ignore": "7.0.5",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.4",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.8.1",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "5.0.3"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^20.12||^22||>=24"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/enhanced-resolve": {
+      "version": "5.22.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
+      "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/dequal": {
@@ -9632,6 +9779,22 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globals": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
@@ -10129,6 +10292,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -10189,6 +10362,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -10492,6 +10675,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -10555,6 +10755,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -12790,7 +13003,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -13146,6 +13359,16 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -16526,6 +16749,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -16833,6 +17070,19 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -16933,6 +17183,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -17290,6 +17550,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {
@@ -17868,6 +18138,13 @@
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -18819,6 +19096,60 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths/node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -19407,6 +19738,19 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^20.12||^22.13||>=24.0"
       }
     },
     "node_modules/wcwidth": {
@@ -20702,8 +21046,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/css-color-parser": {
       "version": "3.1.0",
@@ -20719,8 +21062,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -22297,8 +22639,7 @@
           "version": "7.5.11",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
           "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -22937,6 +23278,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "requires": {
         "csstype": "^3.2.2"
       }
@@ -22944,8 +23286,7 @@
     "@types/react-dom": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "requires": {}
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="
     },
     "@types/responselike": {
       "version": "1.0.3",
@@ -23166,8 +23507,31 @@
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "requires": {}
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+    },
+    "acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true
+    },
+    "acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.15.0"
+      }
+    },
+    "acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.11.0"
+      }
     },
     "adm-zip": {
       "version": "0.5.18",
@@ -24225,6 +24589,12 @@
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
+    "commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -24324,7 +24694,8 @@
     "csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "d": {
       "version": "1.0.2",
@@ -24633,8 +25004,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -24706,6 +25076,68 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
+    },
+    "dependency-cruiser": {
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-17.4.3.tgz",
+      "integrity": "sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w==",
+      "dev": true,
+      "requires": {
+        "acorn": "8.16.0",
+        "acorn-jsx": "5.3.2",
+        "acorn-jsx-walk": "2.0.0",
+        "acorn-loose": "8.5.2",
+        "acorn-walk": "8.3.5",
+        "commander": "14.0.3",
+        "enhanced-resolve": "5.22.1",
+        "ignore": "7.0.5",
+        "interpret": "3.1.1",
+        "is-installed-globally": "1.0.0",
+        "json5": "2.2.3",
+        "picomatch": "4.0.4",
+        "prompts": "2.4.2",
+        "rechoir": "0.8.0",
+        "safe-regex": "2.1.1",
+        "semver": "7.8.1",
+        "tsconfig-paths-webpack-plugin": "4.2.0",
+        "watskeburt": "5.0.3"
+      },
+      "dependencies": {
+        "enhanced-resolve": {
+          "version": "5.22.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
+          "integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.4",
+            "tapable": "^2.3.3"
+          }
+        },
+        "ignore": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+          "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+          "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+          "dev": true
+        }
+      }
     },
     "dequal": {
       "version": "2.0.3",
@@ -25396,8 +25828,7 @@
                 "@typescript-eslint/tsconfig-utils": {
                   "version": "8.63.0",
                   "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-                  "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
-                  "requires": {}
+                  "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg=="
                 }
               }
             },
@@ -26225,6 +26656,15 @@
         "is-glob": "^4.0.3"
       }
     },
+    "global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "requires": {
+        "ini": "4.1.1"
+      }
+    },
     "globals": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
@@ -26551,6 +26991,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true
+    },
     "inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -26601,6 +27047,12 @@
         "hasown": "^2.0.2",
         "side-channel": "^1.1.0"
       }
+    },
+    "interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "dev": true
     },
     "is-alphabetical": {
       "version": "2.0.1",
@@ -26781,6 +27233,16 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
     },
+    "is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "requires": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      }
+    },
     "is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -26816,6 +27278,12 @@
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       }
+    },
+    "is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true
     },
     "is-plain-obj": {
       "version": "4.1.0",
@@ -26942,8 +27410,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -27778,8 +28245,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "30.4.0",
@@ -28307,7 +28773,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true
+      "dev": true
     },
     "jmespath": {
       "version": "0.16.0",
@@ -28578,6 +29044,12 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
     },
     "language-subtag-registry": {
       "version": "0.3.23",
@@ -30544,8 +31016,7 @@
     "preact": {
       "version": "10.29.7",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
-      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
-      "requires": {}
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -30606,6 +31077,16 @@
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
       "integrity": "sha512-p/iXrPSVfnqPft24ZdNNLECw/UrtLTpT3jpAAMzl/o5/rDsGCPo3/CQS2611flL6LkoEJ3oQZw7C8Q80ZISXRQ==",
       "dev": true
+    },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
     },
     "prop-types": {
       "version": "15.8.1",
@@ -30808,6 +31289,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.20.0"
+      }
+    },
     "recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -30876,6 +31366,12 @@
         "get-proto": "^1.0.1",
         "which-builtin-type": "^1.2.1"
       }
+    },
+    "regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.5.4",
@@ -31090,6 +31586,15 @@
       "requires": {
         "es-errors": "^1.3.0",
         "isarray": "^2.0.5"
+      }
+    },
+    "safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "requires": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "safe-regex-test": {
@@ -31320,8 +31825,7 @@
           "version": "7.5.11",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
           "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -31495,6 +31999,12 @@
         "@simple-git/argv-parser": "^1.1.0",
         "debug": "^4.4.0"
       }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
     },
     "slash": {
       "version": "3.0.0",
@@ -32019,8 +32529,7 @@
         "fdir": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-          "requires": {}
+          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="
         },
         "picomatch": {
           "version": "4.0.5",
@@ -32138,8 +32647,7 @@
     "ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "requires": {}
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="
     },
     "tsconfig-paths": {
       "version": "3.15.0",
@@ -32156,6 +32664,43 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+          "dev": true
+        },
+        "tsconfig-paths": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+          "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+          "dev": true,
+          "requires": {
+            "json5": "^2.2.2",
+            "minimist": "^1.2.6",
+            "strip-bom": "^3.0.0"
+          }
         }
       }
     },
@@ -32552,6 +33097,12 @@
         "makeerror": "1.0.12"
       }
     },
+    "watskeburt": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz",
+      "integrity": "sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==",
+      "dev": true
+    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -32717,8 +33268,7 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "5.0.0",
@@ -32873,8 +33423,7 @@
     "zod-validation-error": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
-      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
-      "requires": {}
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="
     },
     "zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.2.17",
+    "dependency-cruiser": "^17.4.3",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "postcss": "^8.5.16",

--- a/scripts/cache-invalidation/graph.mjs
+++ b/scripts/cache-invalidation/graph.mjs
@@ -1,0 +1,105 @@
+// First-party import graph for scripts/invalidate-cloudfront.mjs.
+//
+// buildAdjacency() runs dependency-cruiser over the source tree to get a
+// file -> local-deps map. invertGraph() turns that, plus the route roots
+// from map.mjs, into a file -> route-paths map by transitive
+// reachability: a changed source file invalidates exactly the routes
+// that render it. This replaces the old hand-maintained GLOBAL_FILES
+// list — and the full-purge fallback for any component that wasn't on it.
+//
+// reachableFrom/invertGraph are pure so tests can run them against a
+// synthetic adjacency; only buildAdjacency touches dependency-cruiser,
+// via a dynamic import so importing this module stays cheap.
+
+/** Normalize to a POSIX, repo-relative path so keys match `git diff` output. */
+function normalizePath(filePath) {
+  return filePath.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+/**
+ * Cruise the source dirs and return a file -> first-party-deps adjacency.
+ * node_modules, core modules, and unresolved specifiers are dropped, so
+ * only real repo files remain as edges.
+ *
+ * @returns {Promise<Record<string, string[]>>}
+ */
+export async function buildAdjacency({
+  sourceDirs = ["app", "components", "lib", "styles"],
+  tsConfig = "tsconfig.json",
+} = {}) {
+  const { cruise } = await import("dependency-cruiser");
+
+  const result = await cruise(sourceDirs, {
+    // Resolve the "@/..." alias from tsconfig paths.
+    tsConfig: { fileName: tsConfig },
+    // Follow type-only imports too. Over-approximating is safe here — it
+    // can only widen a route's dependency set, never miss one.
+    tsPreCompilationDeps: true,
+    doNotFollow: { path: "node_modules" },
+    exclude: { path: "(^|/)(node_modules|\\.next|backup)(/|$)" },
+    // Treat CSS and image imports as graph nodes (so styles/globals.css
+    // resolves) without trying to parse their contents.
+    extraExtensionsToScan: [".css", ".svg", ".png", ".jpg", ".jpeg", ".webp", ".gif", ".avif"],
+    enhancedResolveOptions: {
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json", ".css"],
+    },
+  });
+
+  const adjacency = {};
+  for (const mod of result.output.modules ?? []) {
+    adjacency[normalizePath(mod.source)] = (mod.dependencies ?? [])
+      .filter(
+        (dep) =>
+          dep.resolved &&
+          !dep.coreModule &&
+          !dep.couldNotResolve &&
+          !dep.resolved.startsWith("node_modules"),
+      )
+      .map((dep) => normalizePath(dep.resolved));
+  }
+  return adjacency;
+}
+
+/**
+ * Every file transitively reachable from `start` (inclusive of `start`).
+ * @returns {Set<string>}
+ */
+export function reachableFrom(adjacency, start) {
+  const seen = new Set([start]);
+  const stack = [start];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    for (const dep of adjacency[current] ?? []) {
+      if (!seen.has(dep)) {
+        seen.add(dep);
+        stack.push(dep);
+      }
+    }
+  }
+  return seen;
+}
+
+/**
+ * Invert the graph: for each root, every file it reaches accumulates
+ * that root's paths. The result maps a changed source file to the union
+ * of route paths that render it. Files reached by no root are absent —
+ * which classifyChange() treats as "invalidate nothing".
+ *
+ * @param {Record<string, string[]>} adjacency
+ * @param {{ file: string, paths: string[] }[]} roots
+ * @returns {Map<string, Set<string>>}
+ */
+export function invertGraph(adjacency, roots) {
+  const fileToPaths = new Map();
+  for (const root of roots) {
+    for (const file of reachableFrom(adjacency, root.file)) {
+      let paths = fileToPaths.get(file);
+      if (!paths) {
+        paths = new Set();
+        fileToPaths.set(file, paths);
+      }
+      for (const routePath of root.paths) paths.add(routePath);
+    }
+  }
+  return fileToPaths;
+}

--- a/scripts/cache-invalidation/map.mjs
+++ b/scripts/cache-invalidation/map.mjs
@@ -1,0 +1,320 @@
+// Pure mapping logic for scripts/invalidate-cloudfront.mjs: route
+// topology, file classification, and path building. No git, AWS, or
+// dependency-cruiser calls here — everything the classifier needs comes
+// in through a context object, so tests/cache-invalidation.test.ts can
+// exercise every rule directly.
+
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+export const SKIP_MARKER = "[skip-invalidate]";
+
+// Every text route the site currently serves, excluding anything under
+// /images/* or /_next/image* — those are handled separately (and often
+// need nothing at all, see HASHED_IMAGE_RE below).
+export const TEXT_FIXED_PATHS = [
+  "/",
+  "/about",
+  "/contact",
+  "/insights",
+  "/projects",
+  "/work",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/opengraph-image",
+  "/llms.txt",
+];
+
+// Only used by the bootstrap (no tag yet) and diff-failure fallbacks,
+// where nothing is known about what changed. A mapped image change
+// invalidates its own variants instead — see optimizerVariantPaths().
+export const IMAGE_WILDCARD_PATHS = ["/images/*", "/_next/image*"];
+
+// previewImage/diagram source files get copied to a sha256-hashed twin
+// by scripts/build-image-assets.mjs (see lib/images.ts). The hashed
+// file is the only one ever linked to, so a new hash is a brand new
+// URL — nothing to invalidate. This matches that naming scheme.
+export const HASHED_IMAGE_RE = /\.[0-9a-f]{8}(\.og)?\.[a-z0-9]+$/i;
+
+// Hand-versioned static assets (favicon-v2.ico, apple-touch-icon-v2.png,
+// ...): editing one bumps the suffix and produces a new filename/URL on
+// purpose (see the comment in app/layout.tsx), so it never needs
+// invalidating either.
+export const VERSIONED_ASSET_RE = /-v\d+\.[a-z0-9]+$/i;
+
+// Build-level files that can change the bytes of any rendered page but
+// sit outside every page's import graph. They refresh all text routes —
+// never image variants, which only actual image bytes can change.
+// lib/isr-cache-handler.js is here rather than left to the graph: no
+// route imports it, but it writes the payloads pages are served from.
+const BROAD_CONFIG_FILES = new Set([
+  "next.config.js",
+  "postcss.config.js",
+  "tailwind.config.js",
+  "tsconfig.json",
+  "package.json",
+  "package-lock.json",
+  "lib/isr-cache-handler.js",
+  // Root-level Next.js convention files: they ride along with (or run
+  // in front of) every page, so they touch every text route.
+  "instrumentation.ts",
+  "instrumentation-client.ts",
+  "middleware.ts",
+]);
+
+// Repo plumbing that never changes a served byte. Kept explicit so the
+// report can distinguish "known no-op" from "unrecognized file" — both
+// invalidate nothing, but the latter deserves a warning.
+const TOOLING_RE =
+  /^(\.github\/|scripts\/|tests\/|serverless-resources\/|backup\/|docs\/)|^(serverless(\.[a-z]+)?\.yml|jest\.config\.js|jest\.setup\.js|\.eslintrc\.json|\.gitignore|README\.md|next-env\.d\.ts)$/;
+
+const SOURCE_EXT_RE = /\.(tsx?|jsx?|mjs|cjs|css)$/;
+
+/** A file the import graph is expected to cover. */
+export function isSourceFile(file) {
+  return /^(app|components|lib|styles)\//.test(file) && SOURCE_EXT_RE.test(file);
+}
+
+// Derives the served path of an ordinary (non-dynamic) app route file,
+// e.g. "app/about/page.tsx" -> "/about", "app/page.tsx" -> "/". Returns
+// null for dynamic segments ([slug]) — those need slug enumeration and
+// are handled as their own roots below, not generically.
+export function staticRoutePath(file) {
+  const m = file.match(/^app\/(?:(.+)\/)?(page|route)\.(tsx?|jsx?)$/);
+  if (!m) return null;
+  const seg = m[1];
+  if (seg && /[[\]]/.test(seg)) return null;
+  return seg ? `/${seg}` : "/";
+}
+
+export function isPageFile(file) {
+  return /\/page\.(tsx?|jsx?)$/.test(file) || file === "app/page.tsx";
+}
+
+export function listSlugs(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => /\.mdx?$/.test(f))
+    .map((f) => f.replace(/\.mdx?$/, ""));
+}
+
+// Enumerates every current insight/work slug from the checked-out content
+// directories, rather than relying on a "/insights/*"-style wildcard — so
+// the fallback always matches what's actually on the site right now.
+export function fullPathList(ctx) {
+  return [...fullTextPathList(ctx), ...IMAGE_WILDCARD_PATHS];
+}
+
+// Same as above but without the image wildcards — this is what a
+// "global" text-only change (layout, broad config, ...) touches.
+export function fullTextPathList(ctx) {
+  return [
+    ...TEXT_FIXED_PATHS,
+    ...ctx.insightSlugs.map((s) => `/insights/${s}`),
+    ...ctx.workSlugs.map((s) => `/work/${s}`),
+  ];
+}
+
+/**
+ * The optimizer variant paths for one public image, e.g.
+ * "/images/portrait.webp" -> its /_next/image entries and nothing else.
+ * Next's default loader builds "/_next/image?url=<encodeURIComponent(src)>
+ * &w=..&q=..", with url always first, so a trailing wildcard after the
+ * encoded source covers every width/quality variant of exactly this
+ * image. The unencoded twin is cheap insurance against CloudFront
+ * normalizing the invalidation path before matching — both entries stay
+ * scoped to this one source file either way.
+ */
+export function optimizerVariantPaths(urlPath) {
+  return [
+    `/_next/image?url=${encodeURIComponent(urlPath)}*`,
+    `/_next/image?url=${urlPath}*`,
+  ];
+}
+
+// Parses `git diff --name-status`, expanding renames/copies (R100/C100)
+// into a synthetic delete of the old path plus an add of the new one so
+// each path gets classified under its own status.
+export function parseNameStatus(output) {
+  const entries = [];
+  for (const line of output.split("\n").map((l) => l.trim()).filter(Boolean)) {
+    const [statusRaw, ...rest] = line.split("\t");
+    const status = statusRaw[0];
+    if ((status === "R" || status === "C") && rest.length === 2) {
+      entries.push({ file: rest[0], status: "D" });
+      entries.push({ file: rest[1], status: "A" });
+    } else {
+      entries.push({ file: rest[0], status });
+    }
+  }
+  return entries;
+}
+
+/**
+ * Walks app/ and returns the graph roots: every file that owns a URL,
+ * mapped to the path(s) it serves. Dynamic segments expand from the
+ * content slugs in `ctx`; the root layout and not-found page count as
+ * owning every text route. Any app special file this doesn't recognize
+ * (a future template.tsx, a new [param] route) maps to all text routes,
+ * so being generic can only over-refresh, never miss.
+ *
+ * @returns {{ file: string, paths: string[] }[]}
+ */
+export function discoverRoots(ctx, appDir = "app") {
+  const roots = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      const file = full.replace(/\\/g, "/");
+      if (!/\.(tsx?|jsx?)$/.test(entry.name)) continue;
+
+      if (file === `${appDir}/layout.tsx` || file === `${appDir}/not-found.tsx`) {
+        roots.push({ file, paths: fullTextPathList(ctx) });
+      } else if (file === `${appDir}/sitemap.ts`) {
+        roots.push({ file, paths: ["/sitemap.xml"] });
+      } else if (file === `${appDir}/robots.ts`) {
+        roots.push({ file, paths: ["/robots.txt"] });
+      } else if (file === `${appDir}/opengraph-image.tsx`) {
+        roots.push({ file, paths: ["/opengraph-image"] });
+      } else if (file === `${appDir}/insights/[slug]/page.tsx`) {
+        roots.push({
+          file,
+          paths: [
+            ...ctx.insightSlugs.map((s) => `/insights/${s}`),
+            "/insights",
+            "/",
+            "/sitemap.xml",
+          ],
+        });
+      } else if (file === `${appDir}/work/[slug]/page.tsx`) {
+        roots.push({
+          file,
+          paths: [
+            ...ctx.workSlugs.map((s) => `/work/${s}`),
+            "/work",
+            "/",
+            "/sitemap.xml",
+          ],
+        });
+      } else {
+        const servedPath = staticRoutePath(file);
+        if (servedPath !== null) {
+          roots.push({ file, paths: [servedPath] });
+        } else if (/\/(page|route)\.(tsx?|jsx?)$/.test(file)) {
+          // A dynamic route this function doesn't know — refresh broadly.
+          roots.push({ file, paths: fullTextPathList(ctx) });
+        }
+        // Non-route .tsx under app/ (helpers, co-located components) are
+        // ordinary graph nodes, not roots.
+      }
+    }
+  };
+  walk(appDir);
+  return roots;
+}
+
+/**
+ * Classifies one changed file straight to the paths it invalidates.
+ * `status` is git's A/M/D for that path. `ctx` carries the content slugs
+ * and the inverted import graph (`fileToPaths`, a Map of source file ->
+ * Set of route paths — see graph.mjs).
+ *
+ * Returns { bucket, paths, warn? }: `bucket` names the matched rule for
+ * the report, `warn` marks files that deserve a visible heads-up
+ * (unrecognized, or source no route reaches). Unrecognized files
+ * invalidate nothing — a purge of everything wouldn't make an unknown
+ * file's effect any more known, it would just evict hundreds of good
+ * cache entries.
+ */
+export function classifyChange(file, status, ctx) {
+  let m;
+
+  if ((m = file.match(/^content\/insights\/([^/]+)\.mdx?$/))) {
+    return {
+      bucket: "insight",
+      slug: m[1],
+      // A brand-new slug was never cached, so its own path needs nothing.
+      paths: [
+        ...(status === "A" ? [] : [`/insights/${m[1]}`]),
+        "/insights",
+        "/",
+        "/sitemap.xml",
+      ],
+    };
+  }
+  if ((m = file.match(/^content\/work\/([^/]+)\.mdx?$/))) {
+    return {
+      bucket: "work",
+      slug: m[1],
+      paths: [
+        ...(status === "A" ? [] : [`/work/${m[1]}`]),
+        "/work",
+        "/",
+        "/sitemap.xml",
+      ],
+    };
+  }
+  if (file.startsWith("content/projects/"))
+    return { bucket: "projects", paths: ["/projects", "/sitemap.xml"] };
+  if (file.startsWith("content/career/")) return { bucket: "career", paths: ["/about"] };
+  if (file.startsWith("content/skills/")) return { bucket: "skills", paths: ["/about"] };
+  if (file === "content/home.md") return { bucket: "home", paths: ["/", "/about"] };
+  if (file.startsWith("content/"))
+    return { bucket: "content-unmapped", paths: [], warn: true };
+
+  if (file.startsWith("public/images/")) {
+    const name = path.basename(file);
+    if (HASHED_IMAGE_RE.test(name)) {
+      return { bucket: "image-hashed", paths: [] }; // self-busting twin
+    }
+    const urlPath = `/${file.slice("public/".length)}`;
+    return {
+      bucket: "image-direct",
+      paths: [urlPath, ...optimizerVariantPaths(urlPath)],
+    };
+  }
+
+  if (file.startsWith("public/")) {
+    const name = path.basename(file);
+    if (VERSIONED_ASSET_RE.test(name)) {
+      return { bucket: "asset-versioned", paths: [] }; // self-busting
+    }
+    return { bucket: "static-root", paths: [`/${file.slice("public/".length)}`] };
+  }
+
+  if (BROAD_CONFIG_FILES.has(file)) {
+    return { bucket: "broad-config", paths: fullTextPathList(ctx) };
+  }
+
+  if (isSourceFile(file)) {
+    const servedPath = staticRoutePath(file);
+    if (servedPath !== null && status === "A") {
+      // Brand new route: nothing was ever cached at this path, so there's
+      // nothing to purge. New pages need their sitemap entry refreshed;
+      // new non-page routes (API-shaped route.ts) don't even need that.
+      return isPageFile(file)
+        ? { bucket: "new-route", paths: ["/sitemap.xml"] }
+        : { bucket: "new-route", paths: [] };
+    }
+    if (servedPath !== null && status === "D") {
+      // Deleted route: evict the dead URL so it 404s instead of serving
+      // a stale cached copy.
+      return { bucket: "deleted-route", paths: [servedPath, "/sitemap.xml"] };
+    }
+    const reached = ctx.fileToPaths.get(file);
+    if (reached && reached.size > 0) {
+      return { bucket: "code", paths: [...reached] };
+    }
+    // No route reaches it: an orphan, a deleted component (its importers
+    // changed in the same push), or tooling that lives under lib/.
+    return { bucket: "code-unreached", paths: [], warn: status !== "D" };
+  }
+
+  if (TOOLING_RE.test(file)) return { bucket: "tooling", paths: [] };
+
+  return { bucket: "unknown", paths: [], warn: true };
+}

--- a/scripts/invalidate-cloudfront.mjs
+++ b/scripts/invalidate-cloudfront.mjs
@@ -1,89 +1,40 @@
 // Computes which CloudFront paths need invalidating from the git diff
 // since the last successful invalidation, then runs it.
 //
-// Usage: node scripts/invalidate-cloudfront.mjs <dev|prod>
+// Usage: node scripts/invalidate-cloudfront.mjs <dev|prod> [--dry-run]
 // Requires: aws CLI configured, GITHUB_TOKEN + GITHUB_REPOSITORY env vars
 // (both already present by default in a GitHub Actions step), a full
-// (non-shallow) git checkout with tags.
+// (non-shallow) git checkout with tags. --dry-run computes and prints
+// everything but never calls AWS or moves the tag.
+//
+// Mapping logic lives in scripts/cache-invalidation/: map.mjs holds the
+// content/asset rules and route topology, graph.mjs resolves changed
+// source files to the routes that render them via the import graph.
+// Unrecognized files invalidate nothing (they're reported loudly);
+// image changes invalidate only their own optimizer variants.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, appendFileSync } from "node:fs";
-import path from "node:path";
+import { appendFileSync } from "node:fs";
+
+import {
+  SKIP_MARKER,
+  classifyChange,
+  discoverRoots,
+  fullPathList,
+  listSlugs,
+  parseNameStatus,
+} from "./cache-invalidation/map.mjs";
+import { buildAdjacency, invertGraph } from "./cache-invalidation/graph.mjs";
 
 const STAGE = process.argv[2];
+const DRY_RUN = process.argv.includes("--dry-run");
 if (STAGE !== "dev" && STAGE !== "prod") {
-  console.error("Usage: node scripts/invalidate-cloudfront.mjs <dev|prod>");
+  console.error("Usage: node scripts/invalidate-cloudfront.mjs <dev|prod> [--dry-run]");
   process.exit(1);
 }
 
 const TAG = `cf-invalidated-${STAGE}`;
 const STACK_NAME = `portfolio-${STAGE}`;
-const SKIP_MARKER = "[skip-invalidate]";
-
-// Every text route the site currently serves, excluding anything under
-// /images/* or /_next/image* — those are handled separately (and often
-// need nothing at all, see IMAGE_HASHED_RE below).
-const TEXT_FIXED_PATHS = [
-  "/",
-  "/about",
-  "/contact",
-  "/insights",
-  "/projects",
-  "/work",
-  "/robots.txt",
-  "/sitemap.xml",
-  "/opengraph-image",
-  "/llms.txt",
-];
-
-const IMAGE_WILDCARD_PATHS = ["/images/*", "/_next/image*"];
-
-// previewImage/diagram source files get copied to a sha256-hashed twin
-// by scripts/build-image-assets.mjs (see lib/images.ts). The hashed
-// file is the only one ever linked to, so a new hash is a brand new
-// URL — nothing to invalidate. This matches that naming scheme.
-const HASHED_IMAGE_RE = /\.[0-9a-f]{8}(\.og)?\.[a-z0-9]+$/i;
-
-// Hand-versioned static assets (favicon-v2.ico, apple-touch-icon-v2.png,
-// ...): editing one bumps the suffix and produces a new filename/URL on
-// purpose (see the comment in app/layout.tsx), so it never needs
-// invalidating either.
-const VERSIONED_ASSET_RE = /-v\d+\.[a-z0-9]+$/i;
-
-// Shared UI/layout code: rendered on (or affects metadata of) every
-// text route, but never touches image bytes.
-const GLOBAL_FILES = new Set([
-  "app/layout.tsx",
-  "app/not-found.tsx",
-  "lib/site.ts",
-  "lib/seo.ts",
-  "lib/content.ts",
-  "lib/types.ts",
-  "lib/format.ts",
-  "lib/routeDiagram.ts",
-  "components/composites/Nav.tsx",
-  "components/composites/Footer.tsx",
-  "components/composites/StarField.tsx",
-  "components/composites/PageShell.tsx",
-  "components/composites/NebulaBackground.tsx",
-  "components/composites/Breadcrumbs.tsx",
-  "components/composites/Section.tsx",
-  "components/composites/SectionHeading.tsx",
-  "components/composites/TagList.tsx",
-  "components/composites/DividedList.tsx",
-  "components/composites/MdxContent.tsx",
-  "components/composites/Markdown.tsx",
-  "components/composites/mdx-components.tsx",
-  "components/composites/AdjacentNav.tsx",
-  "components/composites/InsightListItem.tsx",
-  "components/composites/CaseStudyListItem.tsx",
-  "components/composites/CapabilityList.tsx",
-  "components/composites/ProjectCard.tsx",
-]);
-
-function isSharedUiPrimitive(file) {
-  return file.startsWith("components/ui/");
-}
 
 function git(args) {
   return execFileSync("git", args, { encoding: "utf8" }).trim();
@@ -102,192 +53,25 @@ function tagExists(tag) {
   }
 }
 
-function listSlugs(dir) {
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir)
-    .filter((f) => /\.mdx?$/.test(f))
-    .map((f) => f.replace(/\.mdx?$/, ""));
+function makeContext() {
+  return {
+    insightSlugs: listSlugs("content/insights"),
+    workSlugs: listSlugs("content/work"),
+    fileToPaths: new Map(),
+  };
 }
 
-// Enumerates every current insight/work slug from the checked-out content
-// directories, rather than relying on a "/insights/*"-style wildcard — so
-// the fallback always matches what's actually on the site right now.
-function fullPathList() {
-  const insightSlugs = listSlugs("content/insights");
-  const workSlugs = listSlugs("content/work");
-  return [
-    ...TEXT_FIXED_PATHS,
-    ...IMAGE_WILDCARD_PATHS,
-    ...insightSlugs.map((s) => `/insights/${s}`),
-    ...workSlugs.map((s) => `/work/${s}`),
-  ];
-}
+async function computeInvalidation() {
+  const ctx = makeContext();
 
-// Same as above but without the image wildcards — this is what a
-// "global" text-only change (layout, nav, site identity, ...) touches.
-function fullTextPathList() {
-  const insightSlugs = listSlugs("content/insights");
-  const workSlugs = listSlugs("content/work");
-  return [
-    ...TEXT_FIXED_PATHS,
-    ...insightSlugs.map((s) => `/insights/${s}`),
-    ...workSlugs.map((s) => `/work/${s}`),
-  ];
-}
-
-// Derives the served path of an ordinary (non-dynamic) app route file,
-// e.g. "app/about/page.tsx" -> "/about", "app/page.tsx" -> "/". Returns
-// null for dynamic segments ([slug]) — those need slug enumeration and
-// are handled as their own bucket below, not generically.
-function staticRoutePath(file) {
-  const m = file.match(/^app\/(?:(.+)\/)?(page|route)\.(tsx?|jsx?)$/);
-  if (!m) return null;
-  const seg = m[1];
-  if (seg && /[[\]]/.test(seg)) return null;
-  return seg ? `/${seg}` : "/";
-}
-
-function isPageFile(file) {
-  return /\/page\.(tsx?|jsx?)$/.test(file) || file === "app/page.tsx";
-}
-
-// Parses `git diff --name-status`, expanding renames/copies (R100/C100)
-// into a synthetic delete of the old path plus an add of the new one so
-// each path gets classified under its own status.
-function parseNameStatus(output) {
-  const entries = [];
-  for (const line of linesOf(output)) {
-    const [statusRaw, ...rest] = line.split("\t");
-    const status = statusRaw[0];
-    if ((status === "R" || status === "C") && rest.length === 2) {
-      entries.push({ file: rest[0], status: "D" });
-      entries.push({ file: rest[1], status: "A" });
-    } else {
-      entries.push({ file: rest[0], status });
-    }
-  }
-  return entries;
-}
-
-// Classifies one changed file into an invalidation bucket. `status` is
-// git's A/M/D (added/modified/deleted) for that path.
-function classify(file, status) {
-  let m;
-
-  if (GLOBAL_FILES.has(file) || isSharedUiPrimitive(file)) {
-    return { bucket: "global" };
-  }
-
-  if (file === "app/insights/[slug]/page.tsx") return { bucket: "template-insight" };
-  if (file === "app/work/[slug]/page.tsx") return { bucket: "template-work" };
-  if (file === "app/robots.ts") return { bucket: "robots" };
-  if (file === "app/sitemap.ts") return { bucket: "sitemap" };
-  if (file === "app/opengraph-image.tsx") return { bucket: "og" };
-
-  const staticPath = staticRoutePath(file);
-  if (staticPath !== null) {
-    if (status === "A") {
-      // Brand new route: nothing was ever cached at this path, so there's
-      // nothing to purge. New pages need their sitemap entry refreshed;
-      // new non-page routes (API-shaped route.ts) don't even need that.
-      return isPageFile(file) ? { bucket: "sitemap" } : { bucket: "noop" };
-    }
-    return { bucket: "static-route", path: staticPath };
-  }
-
-  if ((m = file.match(/^content\/insights\/([^/]+)\.mdx?$/)))
-    return { bucket: "insight", slug: m[1], isNew: status === "A" };
-  if ((m = file.match(/^content\/work\/([^/]+)\.mdx?$/)))
-    return { bucket: "work", slug: m[1], isNew: status === "A" };
-  if (file.startsWith("content/projects/")) return { bucket: "projects" };
-  if (file.startsWith("content/career/")) return { bucket: "career" };
-  if (file.startsWith("content/skills/")) return { bucket: "skills" };
-  if (file === "content/home.md") return { bucket: "home" };
-
-  if (file.startsWith("public/images/")) {
-    const name = path.basename(file);
-    return HASHED_IMAGE_RE.test(name)
-      ? { bucket: "noop" } // self-busting content-hashed twin, see HASHED_IMAGE_RE
-      : { bucket: "image-direct", file };
-  }
-
-  if (file.startsWith("public/")) {
-    const name = path.basename(file);
-    if (VERSIONED_ASSET_RE.test(name)) return { bucket: "noop" }; // self-busting, see VERSIONED_ASSET_RE
-    return { bucket: "static-root", path: `/${file.slice("public/".length)}` };
-  }
-
-  return { bucket: "unknown" };
-}
-
-function addPathsFor(paths, entry) {
-  switch (entry.bucket) {
-    case "global":
-      for (const p of fullTextPathList()) paths.add(p);
-      break;
-    case "template-insight":
-      for (const s of listSlugs("content/insights")) paths.add(`/insights/${s}`);
-      paths.add("/insights");
-      paths.add("/");
-      paths.add("/sitemap.xml");
-      break;
-    case "template-work":
-      for (const s of listSlugs("content/work")) paths.add(`/work/${s}`);
-      paths.add("/work");
-      paths.add("/");
-      paths.add("/sitemap.xml");
-      break;
-    case "static-route":
-      paths.add(entry.path);
-      break;
-    case "insight":
-      if (!entry.isNew) paths.add(`/insights/${entry.slug}`);
-      paths.add("/insights");
-      paths.add("/");
-      paths.add("/sitemap.xml");
-      break;
-    case "work":
-      if (!entry.isNew) paths.add(`/work/${entry.slug}`);
-      paths.add("/work");
-      paths.add("/");
-      paths.add("/sitemap.xml");
-      break;
-    case "projects":
-      paths.add("/projects");
-      paths.add("/sitemap.xml");
-      break;
-    case "career":
-    case "skills":
-      paths.add("/about");
-      break;
-    case "home":
-      paths.add("/");
-      paths.add("/about");
-      break;
-    case "image-direct":
-      paths.add(`/${entry.file.slice("public/".length)}`);
-      paths.add("/_next/image*");
-      break;
-    case "static-root":
-      paths.add(entry.path);
-      break;
-    case "robots":
-      paths.add("/robots.txt");
-      break;
-    case "sitemap":
-      paths.add("/sitemap.xml");
-      break;
-    case "og":
-      paths.add("/opengraph-image");
-      break;
-    case "noop":
-      break;
-  }
-}
-
-function computeInvalidation() {
   if (!tagExists(TAG)) {
-    return { paths: fullPathList(), matches: [], reason: `bootstrap: no ${TAG} tag found yet`, commitRange: [] };
+    return {
+      paths: fullPathList(ctx),
+      matches: [],
+      warnings: [],
+      reason: `bootstrap: no ${TAG} tag found yet`,
+      commitRange: [],
+    };
   }
 
   const commitRange = (() => {
@@ -302,37 +86,36 @@ function computeInvalidation() {
   try {
     changed = parseNameStatus(git(["diff", "--name-status", TAG, "HEAD"]));
   } catch (err) {
-    return { paths: fullPathList(), matches: [], reason: `git diff ${TAG}..HEAD failed: ${err.message}`, commitRange };
-  }
-
-  if (changed.length === 0) {
-    return { paths: [], matches: [], reason: null, commitRange };
-  }
-
-  const paths = new Set();
-  const matches = [];
-  const unknownFiles = [];
-
-  for (const { file, status } of changed) {
-    const entry = classify(file, status);
-    matches.push({ file, status, bucket: entry.bucket, slug: entry.slug });
-    if (entry.bucket === "unknown") {
-      unknownFiles.push(file);
-    } else {
-      addPathsFor(paths, entry);
-    }
-  }
-
-  if (unknownFiles.length > 0) {
     return {
-      paths: fullPathList(),
-      matches,
-      reason: `unmapped file(s) changed, falling back to full invalidation: ${unknownFiles.join(", ")}`,
+      paths: fullPathList(ctx),
+      matches: [],
+      warnings: [],
+      reason: `git diff ${TAG}..HEAD failed: ${err.message}`,
       commitRange,
     };
   }
 
-  return { paths: [...paths], matches, reason: null, commitRange };
+  if (changed.length === 0) {
+    return { paths: [], matches: [], warnings: [], reason: null, commitRange };
+  }
+
+  // The import graph is only needed when source files changed.
+  if (changed.some(({ file }) => /^(app|components|lib|styles)\//.test(file))) {
+    ctx.fileToPaths = invertGraph(await buildAdjacency(), discoverRoots(ctx));
+  }
+
+  const paths = new Set();
+  const matches = [];
+  const warnings = [];
+
+  for (const { file, status } of changed) {
+    const entry = classifyChange(file, status, ctx);
+    matches.push({ file, status, bucket: entry.bucket, slug: entry.slug });
+    for (const p of entry.paths) paths.add(p);
+    if (entry.warn) warnings.push(`\`${file}\` (${entry.bucket}) matched no rule — invalidating nothing for it`);
+  }
+
+  return { paths: [...paths].sort(), matches, warnings, reason: null, commitRange };
 }
 
 async function findSkipMarker(shas) {
@@ -396,13 +179,18 @@ function report(lines) {
 }
 
 async function main() {
-  const { paths, matches, reason, commitRange } = computeInvalidation();
+  const { paths, matches, warnings, reason, commitRange } = await computeInvalidation();
 
-  const lines = [`## CloudFront invalidation — ${STAGE}`, ""];
+  const lines = [`## CloudFront invalidation — ${STAGE}${DRY_RUN ? " (dry run)" : ""}`, ""];
 
   if (matches.length > 0) {
     lines.push("**Matched files:**");
     for (const m of matches) lines.push(`- \`${m.status ?? "?"} ${m.file}\` → ${m.bucket}${m.slug ? ` (${m.slug})` : ""}`);
+    lines.push("");
+  }
+  if (warnings.length > 0) {
+    lines.push("**Warnings:**");
+    for (const w of warnings) lines.push(`- ⚠️ ${w}`);
     lines.push("");
   }
   if (reason) {
@@ -412,11 +200,11 @@ async function main() {
   if (paths.length === 0) {
     lines.push("Nothing to invalidate.");
     report(lines);
-    moveTag();
+    if (!DRY_RUN) moveTag();
     return;
   }
 
-  const distId = getDistributionId(STACK_NAME);
+  const distId = DRY_RUN ? "<distribution-id>" : getDistributionId(STACK_NAME);
   const command = `aws cloudfront create-invalidation --distribution-id ${distId} --paths ${paths
     .map((p) => `"${p}"`)
     .join(" ")}`;
@@ -430,6 +218,12 @@ async function main() {
     lines.push(
       `**Skipped** — PR #${skip.prNumber} ("${skip.prTitle}") in this range is marked \`${SKIP_MARKER}\`. Not running the command above; the tag stays put so these paths roll into the next invalidation that does run.`
     );
+    report(lines);
+    return;
+  }
+
+  if (DRY_RUN) {
+    lines.push("Dry run — not calling AWS, not moving the tag.");
     report(lines);
     return;
   }

--- a/tests/cache-invalidation.test.ts
+++ b/tests/cache-invalidation.test.ts
@@ -1,0 +1,316 @@
+import {
+  classifyChange,
+  discoverRoots,
+  fullPathList,
+  fullTextPathList,
+  optimizerVariantPaths,
+  parseNameStatus,
+  staticRoutePath,
+  listSlugs,
+} from "@/scripts/cache-invalidation/map.mjs";
+import { reachableFrom, invertGraph } from "@/scripts/cache-invalidation/graph.mjs";
+
+/** A minimal context; code files are pre-mapped where a test needs them. */
+function makeContext(fileToPaths = new Map<string, Set<string>>()) {
+  return {
+    insightSlugs: ["ziggy", "groundnet"],
+    workSlugs: ["payment_rebuild", "tableau"],
+    fileToPaths,
+  };
+}
+
+describe("content classification", () => {
+  const ctx = makeContext();
+
+  it("maps an edited insight to its slug, the index, home, and sitemap", () => {
+    const entry = classifyChange("content/insights/ziggy.mdx", "M", ctx);
+    expect(entry.bucket).toBe("insight");
+    expect(entry.paths).toEqual(["/insights/ziggy", "/insights", "/", "/sitemap.xml"]);
+  });
+
+  it("skips the never-cached slug path for a brand-new insight", () => {
+    const entry = classifyChange("content/insights/brand-new.mdx", "A", ctx);
+    expect(entry.paths).toEqual(["/insights", "/", "/sitemap.xml"]);
+  });
+
+  it("maps an edited case study to its slug, the index, home, and sitemap", () => {
+    const entry = classifyChange("content/work/payment_rebuild.md", "M", ctx);
+    expect(entry.bucket).toBe("work");
+    expect(entry.paths).toEqual(["/work/payment_rebuild", "/work", "/", "/sitemap.xml"]);
+  });
+
+  it("maps projects, career, skills, and home content to their pages", () => {
+    expect(classifyChange("content/projects/ziggy.md", "M", ctx).paths).toEqual([
+      "/projects",
+      "/sitemap.xml",
+    ]);
+    expect(classifyChange("content/career/senior.md", "M", ctx).paths).toEqual(["/about"]);
+    expect(classifyChange("content/skills/cloud.md", "M", ctx).paths).toEqual(["/about"]);
+    expect(classifyChange("content/home.md", "M", ctx).paths).toEqual(["/", "/about"]);
+  });
+
+  it("warns on an unmapped content collection instead of purging", () => {
+    const entry = classifyChange("content/experiments/thing.md", "A", ctx);
+    expect(entry.paths).toEqual([]);
+    expect(entry.warn).toBe(true);
+  });
+});
+
+describe("image and asset classification", () => {
+  const ctx = makeContext();
+
+  it("invalidates a changed image's direct path and only its own optimizer variants", () => {
+    const entry = classifyChange("public/images/portrait.webp", "M", ctx);
+    expect(entry.bucket).toBe("image-direct");
+    expect(entry.paths).toEqual([
+      "/images/portrait.webp",
+      "/_next/image?url=%2Fimages%2Fportrait.webp*",
+      "/_next/image?url=/images/portrait.webp*",
+    ]);
+    // Never the global wildcard — other images stay cached.
+    expect(entry.paths).not.toContain("/_next/image*");
+    expect(entry.paths).not.toContain("/images/*");
+  });
+
+  it("treats a content-hashed twin as self-busting", () => {
+    const entry = classifyChange("public/images/ziggy_diagram.bda65046.webp", "A", ctx);
+    expect(entry.bucket).toBe("image-hashed");
+    expect(entry.paths).toEqual([]);
+  });
+
+  it("treats a hand-versioned asset as self-busting", () => {
+    expect(classifyChange("public/favicon-v2.svg", "M", ctx).paths).toEqual([]);
+  });
+
+  it("invalidates a plain public asset at its own path", () => {
+    expect(classifyChange("public/favicon.ico", "M", ctx).paths).toEqual(["/favicon.ico"]);
+  });
+
+  it("scopes optimizer variants to the encoded source path", () => {
+    expect(optimizerVariantPaths("/icons/react-icon.png")).toEqual([
+      "/_next/image?url=%2Ficons%2Freact-icon.png*",
+      "/_next/image?url=/icons/react-icon.png*",
+    ]);
+  });
+});
+
+describe("source code classification", () => {
+  it("resolves a component through the import graph to its routes", () => {
+    const ctx = makeContext(
+      new Map([["components/composites/CareerTimeline.tsx", new Set(["/about"])]])
+    );
+    const entry = classifyChange("components/composites/CareerTimeline.tsx", "M", ctx);
+    expect(entry.bucket).toBe("code");
+    expect(entry.paths).toEqual(["/about"]);
+  });
+
+  it("warns on a source file no route reaches instead of purging", () => {
+    const entry = classifyChange("lib/orphan-helper.ts", "M", makeContext());
+    expect(entry.bucket).toBe("code-unreached");
+    expect(entry.paths).toEqual([]);
+    expect(entry.warn).toBe(true);
+  });
+
+  it("does not warn about a deleted source file", () => {
+    const entry = classifyChange("components/ui/OldButton.tsx", "D", makeContext());
+    expect(entry.paths).toEqual([]);
+    expect(entry.warn).toBeFalsy();
+  });
+
+  it("refreshes only the sitemap for a brand-new page route", () => {
+    const entry = classifyChange("app/lab/page.tsx", "A", makeContext());
+    expect(entry.bucket).toBe("new-route");
+    expect(entry.paths).toEqual(["/sitemap.xml"]);
+  });
+
+  it("purges nothing for a brand-new non-page route", () => {
+    expect(classifyChange("app/api/ping/route.ts", "A", makeContext()).paths).toEqual([]);
+  });
+
+  it("evicts the URL of a deleted route", () => {
+    const entry = classifyChange("app/lab/page.tsx", "D", makeContext());
+    expect(entry.bucket).toBe("deleted-route");
+    expect(entry.paths).toEqual(["/lab", "/sitemap.xml"]);
+  });
+
+  it("refreshes all text routes for broad build config, never images", () => {
+    const ctx = makeContext();
+    for (const file of [
+      "next.config.js",
+      "tailwind.config.js",
+      "postcss.config.js",
+      "package.json",
+      "package-lock.json",
+      "lib/isr-cache-handler.js",
+      "instrumentation-client.ts",
+    ]) {
+      const entry = classifyChange(file, "M", ctx);
+      expect(entry.bucket).toBe("broad-config");
+      expect(entry.paths).toEqual(fullTextPathList(ctx));
+      expect(entry.paths).not.toContain("/_next/image*");
+      expect(entry.paths).not.toContain("/images/*");
+    }
+  });
+});
+
+describe("unknown and tooling files", () => {
+  const ctx = makeContext();
+
+  it("invalidates nothing for repo tooling", () => {
+    for (const file of [
+      ".github/workflows/deploy-prod.yml",
+      "scripts/invalidate-cloudfront.mjs",
+      "scripts/cache-invalidation/map.mjs",
+      "tests/cache-invalidation.test.ts",
+      "serverless.yml",
+      "serverless.prod.yml",
+      "serverless-resources/cloudfront.yml",
+      "jest.config.js",
+      "README.md",
+    ]) {
+      const entry = classifyChange(file, "M", ctx);
+      expect(entry.paths).toEqual([]);
+      expect(entry.warn).toBeFalsy();
+    }
+  });
+
+  it("warns on a completely unknown file but still purges nothing", () => {
+    const entry = classifyChange("mystery/new-thing.xyz", "A", ctx);
+    expect(entry.bucket).toBe("unknown");
+    expect(entry.paths).toEqual([]);
+    expect(entry.warn).toBe(true);
+  });
+});
+
+describe("import graph reachability", () => {
+  //   app/page.tsx       -> Heading, CaseStudyListItem
+  //   app/about/page.tsx -> Heading
+  //   app/layout.tsx     -> Nav, globals.css
+  //   Nav                -> Heading
+  //   CaseStudyListItem  -> Heading
+  //   lib/orphan.ts      -> imported by nobody
+  const adjacency: Record<string, string[]> = {
+    "app/page.tsx": ["components/ui/Heading.tsx", "components/composites/CaseStudyListItem.tsx"],
+    "app/about/page.tsx": ["components/ui/Heading.tsx"],
+    "app/layout.tsx": ["components/composites/Nav.tsx", "styles/globals.css"],
+    "components/composites/Nav.tsx": ["components/ui/Heading.tsx"],
+    "components/composites/CaseStudyListItem.tsx": ["components/ui/Heading.tsx"],
+    "components/ui/Heading.tsx": [],
+    "styles/globals.css": [],
+    "lib/orphan.ts": [],
+  };
+
+  it("includes the start file and everything it transitively imports", () => {
+    expect(reachableFrom(adjacency, "app/page.tsx")).toEqual(
+      new Set([
+        "app/page.tsx",
+        "components/ui/Heading.tsx",
+        "components/composites/CaseStudyListItem.tsx",
+      ])
+    );
+  });
+
+  it("terminates on cycles", () => {
+    expect(reachableFrom({ a: ["b"], b: ["a"] }, "a")).toEqual(new Set(["a", "b"]));
+  });
+
+  describe("invertGraph", () => {
+    const roots = [
+      { file: "app/page.tsx", paths: ["/"] },
+      { file: "app/about/page.tsx", paths: ["/about"] },
+      { file: "app/layout.tsx", paths: ["/", "/about"] },
+    ];
+    const fileToPaths = invertGraph(adjacency, roots);
+
+    it("maps a shared component to every route that renders it", () => {
+      expect([...fileToPaths.get("components/ui/Heading.tsx")!].sort()).toEqual(["/", "/about"]);
+    });
+
+    it("maps a single-page component to just that page", () => {
+      expect([...fileToPaths.get("components/composites/CaseStudyListItem.tsx")!]).toEqual(["/"]);
+    });
+
+    it("maps a layout-only dependency to all pages the layout wraps", () => {
+      expect([...fileToPaths.get("styles/globals.css")!].sort()).toEqual(["/", "/about"]);
+    });
+
+    it("leaves an orphan file absent, meaning no purge", () => {
+      expect(fileToPaths.has("lib/orphan.ts")).toBe(false);
+    });
+  });
+});
+
+describe("route topology against the real app directory", () => {
+  const ctx = makeContext();
+  const roots = discoverRoots(ctx);
+  const byFile = new Map(roots.map((r) => [r.file, r.paths]));
+
+  it("derives static route paths from route files", () => {
+    expect(staticRoutePath("app/page.tsx")).toBe("/");
+    expect(staticRoutePath("app/about/page.tsx")).toBe("/about");
+    expect(staticRoutePath("app/llms.txt/route.ts")).toBe("/llms.txt");
+    expect(staticRoutePath("app/insights/[slug]/page.tsx")).toBeNull();
+    expect(staticRoutePath("components/ui/Heading.tsx")).toBeNull();
+  });
+
+  it("finds every current page and metadata route as a root", () => {
+    expect(byFile.get("app/page.tsx")).toEqual(["/"]);
+    expect(byFile.get("app/about/page.tsx")).toEqual(["/about"]);
+    expect(byFile.get("app/llms.txt/route.ts")).toEqual(["/llms.txt"]);
+    expect(byFile.get("app/sitemap.ts")).toEqual(["/sitemap.xml"]);
+    expect(byFile.get("app/robots.ts")).toEqual(["/robots.txt"]);
+    expect(byFile.get("app/opengraph-image.tsx")).toEqual(["/opengraph-image"]);
+  });
+
+  it("expands dynamic templates with the content slugs", () => {
+    expect(byFile.get("app/insights/[slug]/page.tsx")).toEqual([
+      "/insights/ziggy",
+      "/insights/groundnet",
+      "/insights",
+      "/",
+      "/sitemap.xml",
+    ]);
+    expect(byFile.get("app/work/[slug]/page.tsx")).toContain("/work/payment_rebuild");
+  });
+
+  it("treats the root layout and not-found as owning every text route", () => {
+    expect(byFile.get("app/layout.tsx")).toEqual(fullTextPathList(ctx));
+    expect(byFile.get("app/not-found.tsx")).toEqual(fullTextPathList(ctx));
+  });
+});
+
+describe("path lists and diff parsing", () => {
+  const ctx = makeContext();
+
+  it("keeps image wildcards out of the text path list", () => {
+    const text = fullTextPathList(ctx);
+    expect(text).toContain("/insights/ziggy");
+    expect(text).toContain("/work/tableau");
+    expect(text).toContain("/llms.txt");
+    expect(text).not.toContain("/images/*");
+    expect(text).not.toContain("/_next/image*");
+  });
+
+  it("includes image wildcards only in the bootstrap list", () => {
+    expect(fullPathList(ctx)).toEqual([...fullTextPathList(ctx), "/images/*", "/_next/image*"]);
+  });
+
+  it("expands renames into a delete plus an add", () => {
+    expect(
+      parseNameStatus(
+        "M\tcontent/home.md\nR100\tcontent/insights/old.mdx\tcontent/insights/new.mdx\nD\tpublic/favicon.ico"
+      )
+    ).toEqual([
+      { file: "content/home.md", status: "M" },
+      { file: "content/insights/old.mdx", status: "D" },
+      { file: "content/insights/new.mdx", status: "A" },
+      { file: "public/favicon.ico", status: "D" },
+    ]);
+  });
+
+  it("reads real content slugs off disk", () => {
+    const insights = listSlugs("content/insights");
+    expect(insights).toContain("how-this-site-works");
+    expect(insights.every((slug) => !/\.mdx?$/.test(slug))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Makes the deploy-time CloudFront invalidator map every changed file to exact CDN paths, ending the full-purge fallbacks that evicted hundreds of cached optimized-image variants on unrelated deploys.

## Behavior changes

- **Unknown files invalidate nothing.** Previously any unmapped file fell back to the full path list, including `/images/*` and `/_next/image*`. Now they purge nothing and surface a warning in the step summary.
- **A changed image invalidates only its own variants.** `/images/<file>` plus `/_next/image?url=<encoded>*` scoped to that source file. The global `/_next/image*` wildcard survives only in the once-ever bootstrap fallback.
- **Source files resolve through the import graph.** dependency-cruiser builds the file-to-routes map from the App Router entry files, replacing the hand-maintained `GLOBAL_FILES` list. `CareerTimeline.tsx` now touches `/about` only; `ProjectCard.tsx` touches `/projects` only; components missing from the old list no longer trigger full purges.
- **Broad build config refreshes text routes only.** `next.config.js`, tailwind/postcss, `package.json`/lock, `tsconfig.json`, the ISR cache handler, and instrumentation files refresh every page but never images or hashed static assets.

## Unchanged

Tag anchoring (`cf-invalidated-<stage>`), the `[skip-invalidate]` PR-title marker, bootstrap, A/M/D handling (new slugs/routes purge nothing, deleted routes are evicted), hashed-image and versioned-asset no-ops, step-summary reporting, and the workflow CLI. No workflow edits needed. Adds `--dry-run` for safe local runs.

## Verification

- 61/61 jest tests (33 new covering articles, images, components, config, unknown files, graph reachability, route topology against the real `app/` dir), `tsc` clean.
- Dry-run over the real `cf-invalidated-dev..HEAD` range: precise path list, one image's own variants, warnings instead of full purge. Empty-diff dry-run prints "Nothing to invalidate."
- Real-graph spot checks: `Heading.tsx` maps to all 23 text routes, `lib/nebula/palettes.ts` to every page via the layout, orphan files to nothing.

Note for local use: CI force-moves the tags, so refresh them locally with `git fetch --tags --force` before a `--dry-run`.