### PR TITLE
SEO title lengths, list-page explainers, and share buttons

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -17,7 +17,7 @@ import { pageMetadata, profilePageSchema, breadcrumbSchema } from "@/lib/seo";
 import { site } from "@/lib/site";
 
 export const metadata: Metadata = pageMetadata({
-  title: "About",
+  title: "Engineering leadership & enterprise systems",
   description: "Engineering director and hands-on architect in Toronto. Enterprise modernization, data platforms, AI adoption, and the teams that deliver them.",
   path: "/about",
 });

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -12,7 +12,7 @@ import { site, socialChannels, SocialChannel } from "@/lib/site";
 import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
-  title: "Contact",
+  title: "Contact for architecture & delivery work",
   description: "How to reach Art Nikitin: email, LinkedIn, and GitHub.",
   path: "/contact",
 });

--- a/app/insights/[slug]/page.tsx
+++ b/app/insights/[slug]/page.tsx
@@ -4,6 +4,7 @@ import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import MdxContent from "@/components/composites/MdxContent";
+import ShareButton from "@/components/composites/ShareButton";
 import AdjacentNav from "@/components/composites/AdjacentNav";
 import TagList from "@/components/composites/TagList";
 import Heading from "@/components/ui/Heading";
@@ -25,7 +26,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const insight = getInsight(slug);
   if (!insight) return {};
   return {
-    title: insight.title,
+    // seoTitle keeps the <title> tag under the length search engines
+    // truncate; the punchy headline stays as the OG/on-page title.
+    title: insight.seoTitle ?? insight.title,
     description: insight.description,
     keywords: insight.tags,
     alternates: { canonical: `/insights/${slug}` },
@@ -103,6 +106,12 @@ export default async function InsightPage({ params }: PageProps) {
       <article className="mt-10">
         <MdxContent source={insight.body} />
       </article>
+
+      <ShareButton
+        title={insight.title}
+        path={`/insights/${slug}`}
+        contentType="insight"
+      />
 
       <AdjacentNav
         previous={

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -5,12 +5,16 @@ import SectionHeading from "@/components/composites/SectionHeading";
 import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import DividedList from "@/components/composites/DividedList";
 import InsightListItem from "@/components/composites/InsightListItem";
+import Heading from "@/components/ui/Heading";
+import Text from "@/components/ui/Text";
+import ArrowLink from "@/components/ui/ArrowLink";
 import JsonLd from "@/components/ui/JsonLd";
 import { getInsights } from "@/lib/content";
 import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
+import { mailtoUrl } from "@/lib/site";
 
 export const metadata: Metadata = pageMetadata({
-  title: "Insights",
+  title: "Architecture, AI & engineering write-ups",
   description:
     "Write-ups on architecture, AI, and engineering decisions, written from real projects.",
   path: "/insights",
@@ -48,6 +52,28 @@ export default function InsightsPage() {
           <InsightListItem key={insight.slug} insight={insight} />
         ))}
       </DividedList>
+
+      <section aria-labelledby="insights-about" className="mt-16 border-t border-line/60 pt-10">
+        <Heading size="sub" id="insights-about">
+          What you&rsquo;ll find here
+        </Heading>
+        <Text variant="muted" className="mt-4 max-w-prose">
+          These write-ups come from three places. Some explain how I built a
+          project. Some break down a decision from client work. Some are ideas I
+          gave a client that changed how their business runs. Every one comes
+          from a real system.
+        </Text>
+        <div className="mt-6">
+          <ArrowLink
+            href={mailtoUrl({
+              subject: "A problem I'd like your take on",
+              body: "Hi Art,\n\nI read your write-ups. I'm working through ",
+            })}
+            label="Email me about your business"
+            nebulaShape="email"
+          />
+        </div>
+      </section>
     </PageShell>
   );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -9,7 +9,7 @@ import { getProjectsByEra } from "@/lib/content";
 import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
-  title: "Projects",
+  title: "Personal projects, hardware to AI builds",
   description:
     "Personal projects, past and present. Current work built with AI in the toolchain, and an archive of hardware, games, and tools built entirely by hand.",
   path: "/projects",

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -4,6 +4,7 @@ import PageShell from "@/components/composites/PageShell";
 import NebulaBackground from "@/components/composites/NebulaBackground";
 import Breadcrumbs from "@/components/composites/Breadcrumbs";
 import Markdown from "@/components/composites/Markdown";
+import ShareButton from "@/components/composites/ShareButton";
 import AdjacentNav from "@/components/composites/AdjacentNav";
 import CaseScorecard from "@/components/composites/CaseScorecard";
 import Heading from "@/components/ui/Heading";
@@ -150,6 +151,13 @@ export default async function CaseStudyPage({ params }: PageProps) {
           .
         </Text>
       </div>
+
+      <ShareButton
+        title={caseStudy.title}
+        path={`/work/${slug}`}
+        contentType="case-study"
+        className="mt-8"
+      />
 
       <AdjacentNav
         previous={

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -10,7 +10,7 @@ import CaseScorecard from "@/components/composites/CaseScorecard";
 import Heading from "@/components/ui/Heading";
 import Text from "@/components/ui/Text";
 import Eyebrow from "@/components/ui/Eyebrow";
-import TextLink from "@/components/ui/TextLink";
+import ArrowLink from "@/components/ui/ArrowLink";
 import Exhibit from "@/components/ui/Exhibit";
 import { categoryIcon } from "@/components/ui/Icon";
 import { categoryShape } from "@/lib/nebula/shapes";
@@ -18,7 +18,7 @@ import JsonLd from "@/components/ui/JsonLd";
 import { getCaseStudies, getCaseStudy } from "@/lib/content";
 import { splitAtHeading } from "@/lib/format";
 import { breadcrumbSchema, caseStudySchema, ogImagePath } from "@/lib/seo";
-import { site } from "@/lib/site";
+import { mailtoUrl } from "@/lib/site";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -141,16 +141,30 @@ export default async function CaseStudyPage({ params }: PageProps) {
         </div>
       )}
 
-      <div className="mt-14 border-t border-line/60 pt-8">
-        <Text variant="small">
-          Exact names, figures, and details are confidential. I can walk through the
-          technical decisions in a conversation. Email{" "}
-          <TextLink href={`mailto:${site.email}`} nebulaShape="email">
-            {site.email}
-          </TextLink>
-          .
+      <section
+        aria-labelledby="work-cta"
+        className="mt-14 border-t border-line/60 pt-8"
+      >
+        <Heading size="sub" id="work-cta">
+          Facing something like this?
+        </Heading>
+        <Text variant="muted" className="mt-4 max-w-prose">
+          The client, names, and exact figures stay confidential. The
+          architecture and the results are real. If you are working on a
+          problem like this one, email me. I can walk through how these
+          decisions apply to your systems, or build something similar for you.
         </Text>
-      </div>
+        <div className="mt-6">
+          <ArrowLink
+            href={mailtoUrl({
+              subject: "A system I'd like to talk through",
+              body: `Hi Art,\n\nI read your case study "${caseStudy.title}". I'm working through `,
+            })}
+            label="Email me about your system"
+            nebulaShape="email"
+          />
+        </div>
+      </section>
 
       <ShareButton
         title={caseStudy.title}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -8,12 +8,14 @@ import DividedList from "@/components/composites/DividedList";
 import CaseStudyListItem from "@/components/composites/CaseStudyListItem";
 import Heading from "@/components/ui/Heading";
 import Text from "@/components/ui/Text";
+import ArrowLink from "@/components/ui/ArrowLink";
 import JsonLd from "@/components/ui/JsonLd";
 import { getCaseStudies, getWorkIntro } from "@/lib/content";
 import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
+import { mailtoUrl } from "@/lib/site";
 
 export const metadata: Metadata = pageMetadata({
-  title: "Work",
+  title: "Enterprise modernization case studies",
   description:
     "Case studies from enterprise modernization work: data platforms, payment systems, enrollment pipelines, and delivery automation.",
   path: "/work",
@@ -66,6 +68,28 @@ export default function WorkPage() {
           />
         </section>
       )}
+
+      <section aria-labelledby="work-reading" className="mt-20 border-t border-line/60 pt-10">
+        <Heading size="sub" id="work-reading">
+          How to read these
+        </Heading>
+        <Text variant="muted" className="mt-4 max-w-prose">
+          Each case study is work I led and helped build. The clients are
+          confidential, so identifying details stay out. The decisions and
+          results are real. If one maps to a problem you have, I can walk you
+          through it, or build something similar for you.
+        </Text>
+        <div className="mt-6">
+          <ArrowLink
+            href={mailtoUrl({
+              subject: "A system I'd like to talk through",
+              body: "Hi Art,\n\nI read your case studies. I'm working through ",
+            })}
+            label="Email me about your system"
+            nebulaShape="email"
+          />
+        </div>
+      </section>
     </PageShell>
   );
 }

--- a/components/composites/ShareButton.tsx
+++ b/components/composites/ShareButton.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import posthog from "posthog-js";
+import Icon from "@/components/ui/Icon";
+import Button from "@/components/ui/Button";
+
+interface ShareButtonProps {
+  /** Content title, used for the native share sheet and email subject. */
+  title: string;
+  /** Canonical path, e.g. "/insights/ziggy". The share id is appended to it. */
+  path: string;
+  /** Which collection this is, recorded on the share event. */
+  contentType: "insight" | "case-study";
+  className?: string;
+}
+
+const ID_ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Short, URL-safe, opaque share id, minted fresh per share. It carries
+ * no meaning on its own: the sharer, channel, and content are recorded on
+ * the share_created event, and the id is only the join key that ties that
+ * event to the pageviews the shared link later produces. ~10 base62 chars
+ * is 62^10 (about 8e17) values, far past any collision concern here.
+ */
+function makeShareId(length = 10): string {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  let id = "";
+  for (let i = 0; i < length; i += 1) {
+    id += ID_ALPHABET[bytes[i] % ID_ALPHABET.length];
+  }
+  return id;
+}
+
+type Channel = "native" | "copy" | "linkedin" | "email";
+
+export default function ShareButton({
+  title,
+  path,
+  contentType,
+  className = "mt-12",
+}: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const [canNativeShare, setCanNativeShare] = useState(false);
+
+  // navigator.share is undefined on the server and on most desktops, so
+  // decide after mount to keep the server and first client render equal.
+  useEffect(() => {
+    setCanNativeShare(typeof navigator !== "undefined" && !!navigator.share);
+  }, []);
+
+  // A fresh id per click: every share is its own attributable event. The
+  // origin comes from the live page, so dev and staging shares point at
+  // their own host, and the canonical path drops any existing query string.
+  function mint(): { id: string; url: string } {
+    const id = makeShareId();
+    return { id, url: `${window.location.origin}${path}?s=${id}` };
+  }
+
+  function record(channel: Channel, id: string) {
+    if (process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN) {
+      posthog.capture("share_created", {
+        share_id: id,
+        channel,
+        content_type: contentType,
+        path,
+      });
+    }
+  }
+
+  async function onNative() {
+    const { id, url } = mint();
+    record("native", id);
+    try {
+      await navigator.share({ title, url });
+    } catch {
+      // The user dismissed the share sheet; nothing to do.
+    }
+  }
+
+  async function onCopy() {
+    const { id, url } = mint();
+    record("copy", id);
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard blocked (insecure context or denied permission); the
+      // event still fired, so attribution holds even when the copy fails.
+    }
+  }
+
+  function onLinkedIn() {
+    const { id, url } = mint();
+    record("linkedin", id);
+    window.open(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  }
+
+  function onEmail() {
+    const { id, url } = mint();
+    record("email", id);
+    const body = `Thought you'd find this useful:\n\n${title}\n${url}`;
+    window.location.href = `mailto:?subject=${encodeURIComponent(
+      title,
+    )}&body=${encodeURIComponent(body)}`;
+  }
+
+  return (
+    <section aria-label="Share this page" className={className}>
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-sm text-muted">Share</span>
+
+        {canNativeShare && (
+          <Button
+            variant="outline"
+            shape="pill"
+            onClick={onNative}
+            className="inline-flex items-center gap-2"
+          >
+            <Icon name="share" size={15} />
+            Share
+          </Button>
+        )}
+
+        <Button
+          variant="outline"
+          shape="pill"
+          onClick={onCopy}
+          className="inline-flex items-center gap-2"
+          aria-label={copied ? "Link copied" : "Copy link"}
+        >
+          <Icon name={copied ? "check" : "link"} size={15} />
+          {copied ? "Copied" : "Copy link"}
+        </Button>
+
+        <Button
+          variant="outline"
+          shape="pill"
+          onClick={onLinkedIn}
+          className="inline-flex items-center gap-2"
+        >
+          <Icon name="linkedin" size={15} />
+          LinkedIn
+        </Button>
+
+        <Button
+          variant="outline"
+          shape="pill"
+          onClick={onEmail}
+          className="inline-flex items-center gap-2"
+        >
+          <Icon name="mail" size={15} />
+          Email
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/components/ui/ArrowLink.tsx
+++ b/components/ui/ArrowLink.tsx
@@ -11,16 +11,36 @@ interface ArrowLinkProps {
  *  Muted-until-hover only works where hover exists; touch screens get
  *  full ink so the link reads as tappable instead of disabled. */
 export default function ArrowLink({ href, label, nebulaShape }: ArrowLinkProps) {
-  return (
-    <Link
-      href={href}
-      data-nebula-shape={nebulaShape}
-      className="group inline-flex items-center gap-1.5 text-sm text-ink transition-colors [@media(hover:hover)]:text-muted [@media(hover:hover)]:hover:text-accent"
-    >
+  const className =
+    "group inline-flex items-center gap-1.5 text-sm text-ink transition-colors [@media(hover:hover)]:text-muted [@media(hover:hover)]:hover:text-accent";
+  const inner = (
+    <>
       {label}
       <span aria-hidden className="transition-transform group-hover:translate-x-0.5">
         →
       </span>
+    </>
+  );
+
+  // mailto/external links get a plain anchor; Next's Link is for
+  // in-app routes and doesn't handle the mailto protocol.
+  const external = href.startsWith("http") || href.startsWith("mailto:");
+  if (external) {
+    return (
+      <a
+        href={href}
+        data-nebula-shape={nebulaShape}
+        className={className}
+        {...(href.startsWith("http") ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} data-nebula-shape={nebulaShape} className={className}>
+      {inner}
     </Link>
   );
 }

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -10,7 +10,10 @@ export type IconName =
   | "reporting"
   | "infrastructure"
   | "systems"
-  | "pointer";
+  | "pointer"
+  | "link"
+  | "check"
+  | "share";
 
 interface IconProps {
   name: IconName;
@@ -83,6 +86,21 @@ const icons: Record<IconName, ReactNode> = {
   ),
   pointer: (
     <path d="M4.04 4.69a.5.5 0 0 1 .65-.65l16 6.5a.5.5 0 0 1-.06.94l-6.13 1.58a2 2 0 0 0-1.44 1.44l-1.58 6.13a.5.5 0 0 1-.94.06z" />
+  ),
+  link: (
+    <>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </>
+  ),
+  check: <path d="M20 6 9 17l-5-5" />,
+  share: (
+    <>
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <path d="m8.59 13.51 6.83 3.98M15.41 6.51l-6.82 3.98" />
+    </>
   ),
   github: (
     <path

--- a/content/insights/k3s-homelab.mdx
+++ b/content/insights/k3s-homelab.mdx
@@ -1,5 +1,6 @@
 ---
 title: "A homelab with three-node HA, SSO, and zero open ports"
+seoTitle: "An enterprise-grade Kubernetes homelab"
 description: "Two old laptops, a homemade server, and two mini PCs, none of them enough alone, turned into a five-node Kubernetes cluster with enterprise-grade GitOps, identity, and network discipline."
 previewImage: "/images/k3s_homelab.webp"
 date: "2026-06-09"

--- a/content/insights/ziggy.mdx
+++ b/content/insights/ziggy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ziggy: an assistant built like a brain, not a chatbot"
+seoTitle: "Ziggy: an AI assistant built like a brain"
 description: "A home AI assistant that routes, remembers, and forgets the way a brain does, built on FastMCP, Neo4j, and Haystack."
 previewImage: "/images/ziggy_diagram.webp"
 date: "2025-09-21"

--- a/content/projects/invoice.md
+++ b/content/projects/invoice.md
@@ -4,6 +4,6 @@ title: "Invoice Manager"
 description: "A custom cloud invoice pdf generator."
 thumbnail: "/images/invoice.webp"
 techs: ["nextjs", "tailwind", "mongodb"]
-url: "https://invoice.artemnikitin.dev"
+url: "https://invoice.artnikitin.dev"
 priority: 3
 ---

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -148,6 +148,7 @@ function toInsightMeta(entry: ContentEntry): InsightMeta {
   return {
     slug: entry.slug,
     title: requireString(entry, "title"),
+    seoTitle: typeof entry.data.seoTitle === "string" ? entry.data.seoTitle : undefined,
     description: requireString(entry, "description"),
     previewImage: entry.data.previewImage
       ? fingerprintedPath(entry.data.previewImage as string)

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -21,6 +21,22 @@ export const site = {
     "I design the systems enterprises run on and lead the teams that build them.",
 } as const;
 
+/**
+ * Builds a mailto: link with an optional pre-filled subject and body.
+ * encodeURIComponent (not URLSearchParams) so spaces become %20 and
+ * newlines %0A, which every mail client decodes; the `+` that
+ * URLSearchParams emits is left literal by some clients.
+ */
+export function mailtoUrl({
+  subject,
+  body,
+}: { subject?: string; body?: string } = {}): string {
+  const parts: string[] = [];
+  if (subject) parts.push(`subject=${encodeURIComponent(subject)}`);
+  if (body) parts.push(`body=${encodeURIComponent(body)}`);
+  return `mailto:${site.email}${parts.length ? `?${parts.join("&")}` : ""}`;
+}
+
 export interface SocialChannel {
   key: "email" | "github" | "linkedin";
   label: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,6 +55,9 @@ export interface Project {
 export interface InsightMeta {
   slug: string;
   title: string;
+  /** Shorter title for the <title> tag, when the on-page headline runs
+   *  past the ~60-char length search engines truncate. Falls back to title. */
+  seoTitle?: string;
   description: string;
   /** Editorial image used by insight lists, recommendations, and social previews. */
   previewImage?: string;


### PR DESCRIPTION
Addresses the SEO-audit findings plus two adjacent improvements.

## Titles
- **Too short (5 pages):** rewrote the `<title>` tags for work, about, contact, insights, and projects into the ~50-60 char range with real keywords. Nav labels and H1s are unchanged.
- **Too long (2 insights):** added an optional `seoTitle` frontmatter field (falls back to `title`). Only the `<title>` shrinks — the on-page headline and OG/social title keep the full punchy version.
  - k3s-homelab → `An enterprise-grade Kubernetes homelab`
  - ziggy → `Ziggy: an AI assistant built like a brain`

## Low word count → explainer sections
Rather than padding to a word target, added a genuine closing section to the two list pages:
- **Work:** "How to read these" — what the case studies are (led + built, confidential, real results), with an email CTA.
- **Insights:** "What you'll find here" — the three kinds of write-ups, with an email CTA.
- New `mailtoUrl()` helper pre-fills subject + intro body; `ArrowLink` now renders a plain anchor for `mailto:`/external hrefs.

## Share buttons + attribution groundwork
- New `ShareButton` on insight and case-study pages: Copy link / LinkedIn / Email, plus the native share sheet on mobile.
- Each share mints a fresh opaque `?s=<id>` (10-char base62) and fires a `share_created` PostHog event with `{ share_id, channel, content_type, path }`.
- Recipient side needs no new code now: PostHog already autocaptures `$current_url` (with `?s=`), so the join key lands on both ends. Only the analysis/dashboard is deferred.
- SEO-safe: detail pages already emit canonical URLs without query params, so `?s=` variants consolidate.

`tsc --noEmit` passes. Not visually verified — reviewer should eyeball the share row and the mobile-only native Share button.