### PR TITLE
Polish share buttons and split the case-study CTA

### DIFF
--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -10,7 +10,7 @@ import CaseScorecard from "@/components/composites/CaseScorecard";
 import Heading from "@/components/ui/Heading";
 import Text from "@/components/ui/Text";
 import Eyebrow from "@/components/ui/Eyebrow";
-import ArrowLink from "@/components/ui/ArrowLink";
+import ButtonLink from "@/components/ui/ButtonLink";
 import Exhibit from "@/components/ui/Exhibit";
 import { categoryIcon } from "@/components/ui/Icon";
 import { categoryShape } from "@/lib/nebula/shapes";
@@ -141,28 +141,37 @@ export default async function CaseStudyPage({ params }: PageProps) {
         </div>
       )}
 
+      <div className="mt-14 border-t border-line/60 pt-8">
+        <Text variant="small">
+          Exact names, figures, and details are confidential. I can walk
+          through the technical decisions in a conversation.
+        </Text>
+      </div>
+
       <section
         aria-labelledby="work-cta"
-        className="mt-14 border-t border-line/60 pt-8"
+        className="mt-12 border-t border-line/60 pt-8"
       >
         <Heading size="sub" id="work-cta">
           Facing something like this?
         </Heading>
-        <Text variant="muted" className="mt-4 max-w-prose">
-          The client, names, and exact figures stay confidential. The
-          architecture and the results are real. If you are working on a
-          problem like this one, email me. I can walk through how these
-          decisions apply to your systems, or build something similar for you.
+        <Text variant="muted" className="mt-3 max-w-prose">
+          If your team is up against a problem like this, I can help. Tell me
+          what you are working on and I will show you how I would approach it.
         </Text>
         <div className="mt-6">
-          <ArrowLink
+          <ButtonLink
             href={mailtoUrl({
               subject: "A system I'd like to talk through",
               body: `Hi Art,\n\nI read your case study "${caseStudy.title}". I'm working through `,
             })}
-            label="Email me about your system"
+            variant="solid"
+            shape="pill"
             nebulaShape="email"
-          />
+          >
+            Reach out now
+            <span aria-hidden>→</span>
+          </ButtonLink>
         </div>
       </section>
 

--- a/components/composites/ShareButton.tsx
+++ b/components/composites/ShareButton.tsx
@@ -120,9 +120,10 @@ export default function ShareButton({
 
         {canNativeShare && (
           <Button
-            variant="outline"
+            variant="outline-strong"
             shape="pill"
             onClick={onNative}
+            data-nebula-shape="nodes"
             className="inline-flex items-center gap-2"
           >
             <Icon name="share" size={15} />
@@ -131,9 +132,10 @@ export default function ShareButton({
         )}
 
         <Button
-          variant="outline"
+          variant="outline-strong"
           shape="pill"
           onClick={onCopy}
+          data-nebula-shape="link"
           className="inline-flex items-center gap-2"
           aria-label={copied ? "Link copied" : "Copy link"}
         >
@@ -142,9 +144,10 @@ export default function ShareButton({
         </Button>
 
         <Button
-          variant="outline"
+          variant="outline-strong"
           shape="pill"
           onClick={onLinkedIn}
+          data-nebula-shape="linkedin"
           className="inline-flex items-center gap-2"
         >
           <Icon name="linkedin" size={15} />
@@ -152,9 +155,10 @@ export default function ShareButton({
         </Button>
 
         <Button
-          variant="outline"
+          variant="outline-strong"
           shape="pill"
           onClick={onEmail}
+          data-nebula-shape="email"
           className="inline-flex items-center gap-2"
         >
           <Icon name="mail" size={15} />

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,24 +1,38 @@
 import { ButtonHTMLAttributes } from "react";
 
-type ButtonVariant = "solid" | "outline";
-type ButtonShape = "rounded" | "pill";
-
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariant;
-  shape?: ButtonShape;
-}
+export type ButtonVariant = "solid" | "outline" | "outline-strong";
+export type ButtonShape = "rounded" | "pill";
 
 const variantClasses: Record<ButtonVariant, string> = {
   solid:
     "bg-accent text-accent-ink font-semibold transition-opacity hover:opacity-90 disabled:opacity-40",
   outline:
     "border border-line text-muted transition-colors hover:border-accent/60 hover:text-ink disabled:opacity-40",
+  // Reads as clearly interactive rather than disabled: full-ink label, and
+  // both border and text move to accent on hover.
+  "outline-strong":
+    "border border-line text-ink transition-colors hover:border-accent hover:text-accent disabled:opacity-40",
 };
 
 const shapeClasses: Record<ButtonShape, string> = {
   rounded: "rounded-md",
   pill: "rounded-full",
 };
+
+/** The class string shared by Button and ButtonLink, so an anchor styled as
+ *  a button stays visually identical to the real thing. */
+export function buttonClasses(
+  variant: ButtonVariant = "solid",
+  shape: ButtonShape = "rounded",
+  className = "",
+): string {
+  return `px-4 py-1.5 text-sm ${variantClasses[variant]} ${shapeClasses[shape]} ${className}`;
+}
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  shape?: ButtonShape;
+}
 
 /** The button. Every button on the site is one of these. */
 export default function Button({
@@ -30,11 +44,7 @@ export default function Button({
   ...rest
 }: ButtonProps) {
   return (
-    <button
-      type={type}
-      className={`px-4 py-1.5 text-sm ${variantClasses[variant]} ${shapeClasses[shape]} ${className}`}
-      {...rest}
-    >
+    <button type={type} className={buttonClasses(variant, shape, className)} {...rest}>
       {children}
     </button>
   );

--- a/components/ui/ButtonLink.tsx
+++ b/components/ui/ButtonLink.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { buttonClasses, ButtonVariant, ButtonShape } from "./Button";
+
+interface ButtonLinkProps {
+  href: string;
+  children: ReactNode;
+  variant?: ButtonVariant;
+  shape?: ButtonShape;
+  className?: string;
+  /** Shape key the nebula background condenses into while hovered. */
+  nebulaShape?: string;
+}
+
+/**
+ * An anchor that looks like a Button. Internal paths use Next's Link;
+ * external and mailto links get a plain anchor with target/rel handling
+ * (mirrors TextLink, since Next's Link doesn't handle the mailto protocol).
+ */
+export default function ButtonLink({
+  href,
+  children,
+  variant = "solid",
+  shape = "rounded",
+  className = "",
+  nebulaShape,
+}: ButtonLinkProps) {
+  const classes = buttonClasses(
+    variant,
+    shape,
+    `inline-flex items-center justify-center gap-2 ${className}`,
+  );
+  const external = href.startsWith("http") || href.startsWith("mailto:");
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        className={classes}
+        data-nebula-shape={nebulaShape}
+        {...(href.startsWith("http") ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={classes} data-nebula-shape={nebulaShape}>
+      {children}
+    </Link>
+  );
+}

--- a/lib/nebula/shapes.ts
+++ b/lib/nebula/shapes.ts
@@ -54,6 +54,9 @@ export const nebulaShapes: Record<string, string> = {
   // Puffy cloud: cloud platforms.
   cloud:
     "stroke:M26 78 C12 78 6 68 10 58 C12 53 16 50 21 49 C17 37 27 28 38 31 C43 18 64 17 72 31 C84 27 94 36 92 48 C98 53 98 63 93 69 C89 75 82 78 72 78 Z",
+  // Two interlocking capsules: a chain link, for "copy link".
+  link:
+    "stroke:M23 35 L43 35 A15 15 0 0 1 43 65 L23 65 A15 15 0 0 1 23 35 Z M57 35 L77 35 A15 15 0 0 1 77 65 L57 65 A15 15 0 0 1 57 35 Z",
 };
 
 export type NebulaShapeKey = keyof typeof nebulaShapes;


### PR DESCRIPTION
Iteration on the share buttons and the case-study footer, from testing on dev.

## Share buttons
- No longer muted: new `outline-strong` Button variant renders a full-ink label with an accent border+text on hover, so they read as clearly clickable instead of disabled.
- Each button now morphs the nebula on hover via `data-nebula-shape`:
  - LinkedIn → `linkedin`, Email → `email`, native Share → `nodes`
  - **Copy link → new `link` glyph** (two interlocking capsules / chain link)

## Case-study footer — two separate sections
- The confidentiality note goes back to being just that: a plain NDA disclaimer.
- A distinct CTA section follows it, nudging a decision-maker to reach out ("Facing something like this?") with a solid **Reach out now** button (pre-filled mailto referencing the case study).

## Supporting
- New `ButtonLink` (an anchor styled as a Button, mailto/external-aware like TextLink), plus a shared `buttonClasses()` builder extracted from Button so the CTA anchor matches a real button exactly.

`tsc --noEmit` passes. Not visually verified here — please eyeball on dev: button contrast, the copy-link nebula morph, and the two-section footer.