### PR TITLE
Remove em dashes from Tableau case study FAQ answers

### DIFF
--- a/content/work/tableau.md
+++ b/content/work/tableau.md
@@ -20,9 +20,9 @@ context:
     value: "99.9% target"
 comments:
   - question: "Can you hand the business an entire BI tool and call the job done?"
-    answer: "No. Engineering delivery is complex. You are not delivering a pizza, where the end goal and how to use it are obvious. You have to walk the business from the data marts all the way to the dashboard, build the solution hand in hand, and deliver the complete operating process—with documentation, operational notes, and support runbooks."
+    answer: "No. Engineering delivery is complex. You are not delivering a pizza, where the end goal and how to use it are obvious. You have to walk the business from the data marts all the way to the dashboard, build the solution hand in hand, and deliver the complete operating process, along with documentation, operational notes, and support runbooks."
   - question: "What turns a Tableau server into an enterprise BI platform?"
-    answer: "Data governance, auditing, observability, maintainability, and the support model make the difference. You cannot simply spin up a Tableau server and call it done. It has to connect to the employee directory, restrict data to the people who need it, prevent network leakage, and minimize threat vectors. The system also needs enough flexibility—and the team enough expertise—that when the CCO says, “My dashboard is slow,” you can quickly find the bottleneck."
+    answer: "Data governance, auditing, observability, maintainability, and the support model make the difference. You cannot simply spin up a Tableau server and call it done. It has to connect to the employee directory, restrict data to the people who need it, prevent network leakage, and minimize threat vectors. The system also needs enough flexibility, and the team enough expertise, that when the CCO says, “My dashboard is slow,” you can quickly find the bottleneck."
 ---
 
 ## The problem


### PR DESCRIPTION
## Summary

Rewrites two FAQ answers in `content/work/tableau.md` to remove em dashes while preserving meaning and rhythm.

## Changes

- "operating process—with documentation" → "operating process, along with documentation"
- The paired em dashes around "and the team enough expertise" → paired commas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JV2GZw9yuzF3AtpKHBGF1P

---
_Generated by [Claude Code](https://claude.ai/code/session_01JV2GZw9yuzF3AtpKHBGF1P)_