### PR TITLE
Fix duplicate h1 on homepage (SEO)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -340,7 +340,12 @@ export default function HomePage() {
                         <span aria-hidden className="h-px flex-1 bg-line/60" />
                         <span>{site.location}</span>
                       </div>
-                      <Heading size="hero" className="max-w-3xl">
+                      {/* Rendered as <p>, not <h1>: this desktop hero is a
+                          responsive duplicate of the mobile hero above, which
+                          owns the page's single <h1>. Emitting a second <h1>
+                          here would put two in the page source (both are always
+                          in the DOM, only one visible per breakpoint). */}
+                      <Heading size="hero" as="p" className="max-w-3xl">
                         I design the{" "}
                         <span className="text-accent" data-nebula-shape="hex">
                           systems

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -1,11 +1,16 @@
 import { ReactNode } from "react";
 
-type HeadingLevel = "h1" | "h2" | "h3";
+type HeadingLevel = "h1" | "h2" | "h3" | "p";
 type HeadingSize = "hero" | "page" | "section" | "sub" | "item" | "small";
 
 interface HeadingProps {
   children: ReactNode;
-  /** Semantic tag. Defaults follow size: hero/page → h1, section/sub → h2, item/small → h3. */
+  /**
+   * Semantic tag. Defaults follow size: hero/page → h1, section/sub → h2,
+   * item/small → h3. Pass "p" to keep the visual size without emitting a
+   * heading — e.g. a duplicated responsive hero that must not add a second
+   * <h1> to the page source.
+   */
   as?: HeadingLevel;
   size: HeadingSize;
   id?: string;


### PR DESCRIPTION
## What & why

Bing Webmaster Tools flagged the homepage with **"More than one h1 tag — 2 instances found."**

The homepage (`app/page.tsx`) ships two responsive hero variants:

- a **mobile** layout inside `<div className="md:hidden">`
- a **desktop** layout inside `<div className="hidden md:block">`

Only one is *visible* at a given breakpoint, but **both are always in the page source** — CSS only toggles visibility. Both used `size="hero"`, which the `Heading` component maps to `<h1>`, so any crawler reading the raw HTML (Bing, and static SEO parsers generally) saw two `<h1>` tags.

## The fix

- Added an `as="p"` option to `Heading` (`components/ui/Heading.tsx`) so a heading can keep its visual size without emitting a heading tag.
- The **mobile** hero keeps the single real `<h1>` (aligns with mobile-first indexing).
- The **desktop** hero now renders as a visually-identical `<p>`.

Result: exactly one `<h1>` in the page source, with **no visual or layout change** on either breakpoint.

## Testing

- `npx tsc --noEmit` — 0 errors
- `npx jest` — 67/67 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPFpwJ3zNtXFu9rHJKtGLd)_