### PR TITLE
SEO.md compliance: meta descriptions and hero heading semantics

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,7 +13,8 @@ import { pageMetadata, breadcrumbSchema } from "@/lib/seo";
 
 export const metadata: Metadata = pageMetadata({
   title: "Contact for architecture & delivery work",
-  description: "How to reach Art: email, LinkedIn, and GitHub.",
+  description:
+    "How to reach Art for modernization work, architecture questions, or speaking: email, LinkedIn, and GitHub, with a note on when to use each channel.",
   path: "/contact",
 });
 

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -16,7 +16,7 @@ import { mailtoUrl } from "@/lib/site";
 export const metadata: Metadata = pageMetadata({
   title: "Architecture, AI & engineering write-ups",
   description:
-    "Write-ups on architecture, AI, and engineering decisions, written from real projects.",
+    "Write-ups on architecture, AI, and engineering decisions from real projects: RAG agents, Kubernetes platforms, AI safety, and AI-assisted delivery.",
   path: "/insights",
 });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import PageShell from "@/components/composites/PageShell";
@@ -22,6 +23,29 @@ import {
 import { formatDate } from "@/lib/format";
 import { personSchema, websiteSchema } from "@/lib/seo";
 import { site } from "@/lib/site";
+
+// The layout's default description is the ~75-character brand line; search
+// snippets fill 120–160. This names what the site delivers without touching
+// the on-page hero. The <title> stays on the layout default.
+const homeDescription =
+  "I design the systems enterprises run on. Case studies and write-ups on enterprise modernization, data platforms, AI adoption, and engineering leadership.";
+
+export const metadata: Metadata = {
+  description: homeDescription,
+  openGraph: {
+    type: "website",
+    siteName: site.name,
+    url: site.url,
+    title: `${site.name} · ${site.tagline}`,
+    description: homeDescription,
+    locale: "en_CA",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${site.name} · ${site.tagline}`,
+    description: homeDescription,
+  },
+};
 
 // Shared glass-card shell for the horizontal rails. A fixed width lets the
 // next card peek, which is the whole "swipe me" signal.

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -34,14 +34,15 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = await params;
   const caseStudy = getCaseStudy(slug);
   if (!caseStudy) return {};
+  const description = caseStudy.seoDescription ?? caseStudy.impact;
   return {
     title: caseStudy.title,
-    description: caseStudy.impact,
+    description,
     keywords: [...(caseStudy.keywords ?? []), ...caseStudy.techs],
     alternates: { canonical: `/work/${slug}` },
     openGraph: {
       title: caseStudy.title,
-      description: caseStudy.impact,
+      description,
       url: `/work/${slug}`,
       type: "article",
       publishedTime: new Date(caseStudy.date).toISOString(),
@@ -51,7 +52,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     twitter: {
       card: "summary_large_image",
       title: caseStudy.title,
-      description: caseStudy.impact,
+      description,
       images: caseStudy.diagram ? [ogImagePath(caseStudy.diagram)] : undefined,
     },
   };

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -8,8 +8,10 @@ interface HeadingProps {
   /**
    * Semantic tag. Defaults follow size: hero/page → h1, section/sub → h2,
    * item/small → h3. Pass "p" to keep the visual size without emitting a
-   * heading — e.g. a duplicated responsive hero that must not add a second
-   * <h1> to the page source.
+   * heading tag — e.g. a duplicated responsive hero that must not add a
+   * second <h1> to the page source. ARIA still exposes the size's heading
+   * level, so the breakpoint where the real twin is display:none (and gone
+   * from the accessibility tree) keeps a heading for assistive tech.
    */
   as?: HeadingLevel;
   size: HeadingSize;
@@ -44,8 +46,12 @@ const sizeClasses: Record<HeadingSize, string> = {
 /** The heading. Every title and subtitle on the site is one of these. */
 export default function Heading({ children, as, size, id, className = "" }: HeadingProps) {
   const Tag = as ?? defaultTag[size];
+  const aria =
+    Tag === "p"
+      ? ({ role: "heading", "aria-level": Number(defaultTag[size].slice(1)) } as const)
+      : undefined;
   return (
-    <Tag id={id} className={`font-display text-ink ${sizeClasses[size]} ${className}`}>
+    <Tag id={id} {...aria} className={`font-display text-ink ${sizeClasses[size]} ${className}`}>
       {children}
     </Tag>
   );

--- a/content/work/sdlc-revamp.md
+++ b/content/work/sdlc-revamp.md
@@ -4,6 +4,7 @@ date: "2025-09-01"
 techs: ["azure", "azure-pipelines", "iac", "powershell"]
 keywords: ["SDLC", "deployment automation", "release management", "CI/CD pipeline", "DevOps"]
 impact: "Modernized the SDLC to cut deployment time from a week to four hours, bug to production."
+seoDescription: "How a 1M-customer web platform cut bug-to-production time from a week to four hours: build-once artifacts, staged promotion, and automated releases."
 priority: 2
 category: infrastructure
 role: "Led release-process modernization"

--- a/content/work/student-pipeline.md
+++ b/content/work/student-pipeline.md
@@ -4,6 +4,7 @@ date: "2023-12-01"
 techs: ["aws", "typescript", "python", "serverless", "splunk"]
 keywords: ["student pipeline", "enrollment processing", "student data pipeline", "SFTP integration", "reconciliation workflow"]
 impact: "Rebuilt the student enrollment pipeline to remove a week-long manual delay for 1M+ students."
+seoDescription: "How a monthly enrollment pipeline for 1M+ students replaced a week-long manual delay: SFTP ingestion, state reconciliation, and nightly delta delivery."
 priority: 6
 category: infrastructure
 role: "Led architecture and delivery"

--- a/content/work/tableau.md
+++ b/content/work/tableau.md
@@ -4,6 +4,7 @@ date: "2025-01-01"
 techs: ["tableau", "aws", "redshift", "python", "ec2"]
 keywords: ["Tableau integration", "business intelligence", "BI platform", "data visualization"]
 impact: "Created a governed BI platform so business teams could access warehouse data directly."
+seoDescription: "How a governed Tableau platform on AWS gave business teams direct warehouse access: identity controls, private networking, and a 99.9% availability target."
 priority: 8
 category: reporting
 role: "Led platform design and automation"

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -113,6 +113,8 @@ export function getCaseStudies(): CaseStudy[] {
       title: requireString(entry, "title"),
       date: requireString(entry, "date"),
       impact: requireString(entry, "impact"),
+      seoDescription:
+        typeof entry.data.seoDescription === "string" ? entry.data.seoDescription : undefined,
       techs: (entry.data.techs as string[]) ?? [],
       keywords: (entry.data.keywords as string[]) ?? [],
       category: (entry.data.category as string) ?? "systems",

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -156,7 +156,7 @@ export function caseStudySchema(caseStudy: CaseStudy) {
     "@type": "Article",
     name: caseStudy.title,
     headline: caseStudy.title,
-    description: caseStudy.impact,
+    description: caseStudy.seoDescription ?? caseStudy.impact,
     datePublished: published,
     dateModified: published,
     inLanguage: "en-CA",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,6 +20,10 @@ export interface CaseStudy {
    *  Feeds structured data; not shown on the page. */
   date: string;
   impact: string;
+  /** Meta-description override for search snippets, when the on-page
+   *  impact line runs short of the 120–160 characters engines fill.
+   *  Falls back to impact. */
+  seoDescription?: string;
   techs: string[];
   /** Search-intent phrases for this case study, e.g. "data warehouse". Feeds meta keywords and JSON-LD, distinct from techs. */
   keywords?: string[];


### PR DESCRIPTION
Audit of every page and article against SEO.md, prompted by Bing Webmaster flags.

## Changes

- **Meta descriptions into the 120–160 band.** Home (75→153), /insights (85→147), and /contact (46→147) each get a description naming what the page delivers. The home description is page-level metadata; the on-page hero and brand line are untouched.
- **`seoDescription` frontmatter for case studies.** Mirrors the existing `seoTitle` pattern for insights: feeds the meta description and Article JSON-LD, falls back to `impact`. Applied to `sdlc-revamp` (90→148), `student-pipeline` (94→151), and `tableau` (88→155), whose on-page impact lines stay as written. All new copy uses only facts already in each file.
- **ARIA level on the demoted hero.** The desktop hero twin (rendered as `p` since #118's duplicate-h1 fix) now carries `role="heading" aria-level="1"`, so the breakpoint where the real `h1` is `display:none` still exposes a level-1 heading to assistive tech.

## What already passed the audit

Titles (44–62 chars, decision-first with brand suffix), self-referencing canonicals, one H1 per page, og/twitter tags, visible bylines linking to /about, `max-image-preview:large`, robots.txt, the /md mirror's `rel=canonical` header, JSON-LD (Person, WebSite, ProfilePage, Article, BreadcrumbList), 1200×630 OG image, square 48px+ favicon.

## Flagged, not changed

- Case-study schema marks the delivery date as `datePublished`/`dateModified` and no date is visible on-page (documented as deliberate in `lib/types.ts`).
- GroundNet and Ziggy link no case study; no relevant one exists yet, and SEO.md's rule applies only "when those pages exist".
- Article schema carries one image; the guide asks for 16:9/4:3/1:1 crops ≥50k px (build-script work).
- /work sitemap entries have no `lastModified`; the only available date is project delivery, which would be untruthful as a modification date.