### PR TITLE
Add zero-bars Easter egg to Human Review Lab

### DIFF
--- a/components/composites/HumanReviewLab.tsx
+++ b/components/composites/HumanReviewLab.tsx
@@ -161,6 +161,9 @@ export default function HumanReviewLab({ description }: HumanReviewLabProps) {
     outcome = `However, there ${techDebt === 1 ? "is" : "are"} now ${techDebt} story ${techDebt === 1 ? "point" : "points"} of technical debt, and ${productionBugs}.`;
   }
 
+  // Easter egg: no business ask means every bar sits at zero.
+  const allZero = businessDays === 0 && buildDays === 0 && reviewDays === 0 && qaDays === 0;
+
   const escapedContext = escaped === 1
     ? reviewDays === 0
       ? "The bug was caused by a difference between the non-production and production environments that the QA team did not know about."
@@ -281,7 +284,9 @@ export default function HumanReviewLab({ description }: HumanReviewLabProps) {
             With the time above, your result:
           </p>
           <p className="mt-2 text-sm leading-relaxed text-ink sm:mt-3 sm:text-[1rem]">
-            The business asked for one feature that should take {days(businessDays)}. In {days(releaseDays)} total, AI wrote enough code to {scopePhrase}. {outcome}{escapedContext ? ` ${escapedContext}` : ""}
+            {allZero
+              ? "The business didn't ask you for anything. You now have time to scroll your phone, with no additional tech debt or production bugs."
+              : <>The business asked for one feature that should take {days(businessDays)}. In {days(releaseDays)} total, AI wrote enough code to {scopePhrase}. {outcome}{escapedContext ? ` ${escapedContext}` : ""}</>}
           </p>
         </div>
 

--- a/components/composites/HumanReviewLab.tsx
+++ b/components/composites/HumanReviewLab.tsx
@@ -285,7 +285,7 @@ export default function HumanReviewLab({ description }: HumanReviewLabProps) {
           </p>
           <p className="mt-2 text-sm leading-relaxed text-ink sm:mt-3 sm:text-[1rem]">
             {allZero
-              ? "The business didn't ask you for anything. You now have time to scroll your phone, with no additional tech debt or production bugs."
+              ? "The business didn't ask you for anything. You now have time to scroll your phone, with no additional tech debt or production bugs to bother you this month."
               : <>The business asked for one feature that should take {days(businessDays)}. In {days(releaseDays)} total, AI wrote enough code to {scopePhrase}. {outcome}{escapedContext ? ` ${escapedContext}` : ""}</>}
           </p>
         </div>


### PR DESCRIPTION
## Summary

Adds a small Easter egg to the Human Review Lab interactive figure. When all four bars are at zero (dragging **Business ask** to 0 forces AI coding, Human review, and QA to 0 as well), the result message swaps to a playful note instead of the usual shipping-equation outcome:

> The business didn't ask you for anything. You now have time to scroll your phone, with no additional tech debt or production bugs to bother you this month.

Any other bar combination shows the normal outcome as before.

## Changes

- `components/composites/HumanReviewLab.tsx` — added an `allZero` check and conditionally render the Easter egg copy in the result box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013aWYbknho2e4tHBzpC3hLv)_